### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"cakephp/cakephp": "3.0.x-dev"
+		"cakephp/cakephp": "~3.0"
 	},
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-geo"


### PR DESCRIPTION
Changed the basic requirement to CakePHP ~3.0 and not 3.0.x-dev. This is causing a dependency error in composer when trying to include this package on new CakePHP ~3.0 installations due to it's requirement of "dev". Not sure if that makes sense.