### PR TITLE
added document root for local url in getimagesize

### DIFF
--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -848,8 +848,14 @@ function geocodeAddress(address) {
 		// while the position and offset are the same as for the main image.
 		if (empty($options['size'])) {
 			if (substr($url, 0, 1) === '/') {
-				// patch local paths to use the document root.
-				$data = getimagesize(realpath(WWW_ROOT . $url));
+				// patch local paths to use the document root.  otherwise getimagesize fails filesystem lookup.
+				// paths with http or other protocol in front will be handled more simply in 'else' below.
+				$canonicalPath = realpath(WWW_ROOT . $url);
+				if (! $canonicalPath) {
+					// failed to resolve the path, so just fall back to the url provided.
+					$canonicalPath = "$url";
+				}
+				$data = getimagesize($canonicalPath);
 			} else {
 				$data = getimagesize($url);
 			}

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -849,7 +849,7 @@ function geocodeAddress(address) {
 		if (empty($options['size'])) {
 			if (substr($url, 0, 1) === '/') {
 				// patch local paths to use the document root.
-				$data = getimagesize($_SERVER['DOCUMENT_ROOT'] . $url);
+				$data = getimagesize(WWW_ROOT . $url);
 			} else {
 				$data = getimagesize($url);
 			}

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -849,7 +849,7 @@ function geocodeAddress(address) {
 		if (empty($options['size'])) {
 			if (substr($url, 0, 1) === '/') {
 				// patch local paths to use the document root.
-				$data = real_path(getimagesize(WWW_ROOT . $url));
+				$data = realpath(getimagesize(WWW_ROOT . $url));
 			} else {
 				$data = getimagesize($url);
 			}

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -847,7 +847,12 @@ function geocodeAddress(address) {
 		// The shadow image is larger in the horizontal dimension
 		// while the position and offset are the same as for the main image.
 		if (empty($options['size'])) {
-			$data = getimagesize($url);
+			if (substr($url, 0, 1) === '/') {
+				// patch local paths to use the document root.
+				$data = getimagesize($_SERVER['DOCUMENT_ROOT'] . $url);
+			} else {
+				$data = getimagesize($url);
+			}
 			if ($data) {
 				$options['size']['width'] = $data[0];
 				$options['size']['height'] = $data[1];

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -849,7 +849,7 @@ function geocodeAddress(address) {
 		if (empty($options['size'])) {
 			if (substr($url, 0, 1) === '/') {
 				// patch local paths to use the document root.
-				$data = getimagesize(WWW_ROOT . $url);
+				$data = real_path(getimagesize(WWW_ROOT . $url));
 			} else {
 				$data = getimagesize($url);
 			}

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -849,7 +849,7 @@ function geocodeAddress(address) {
 		if (empty($options['size'])) {
 			if (substr($url, 0, 1) === '/') {
 				// patch local paths to use the document root.
-				$data = realpath(getimagesize(WWW_ROOT . $url));
+				$data = getimagesize(realpath(WWW_ROOT . $url));
 			} else {
 				$data = getimagesize($url);
 			}


### PR DESCRIPTION
discovered a problem with local URLs (relative to webroot) when adding marker icons, where the getimagesize in GoogleMapHelper was failing on a path like '/img/myicon.png'.  some digging on the web revealed that getimagesize wants the server's document root prepended to the url for the size operation to work, so that is what i added.  this made the complaint go away about finding the site-relative image, and the image shows as expected.