### PR TITLE
Remove routing deprecations

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,9 +1,8 @@
 <?php
 
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Router;
 
-Router::prefix('Admin', function (RouteBuilder $routes) {
+$routes->prefix('Admin', function (RouteBuilder $routes) {
 	$routes->plugin('Geo', function (RouteBuilder $routes) {
 		$routes->connect('/', ['controller' => 'Geo', 'action' => 'index']);
 


### PR DESCRIPTION
`Router::prefix()` is deprecated since Cakephp 4.3. : 
https://book.cakephp.org/4.next/en/appendices/4-3-migration-guide.html

Replaced by a call to the non-static method `RouteBuilder::prefix()`.