### PR TITLE
72 - Remove CakePHP Adapter in favor of official Cake Client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.2']
+        php-version: ['8.1', '8.3']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 
@@ -67,7 +67,7 @@ jobs:
           if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
           if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
           if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
-          if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.db-type }} == 'sqlite' ]]; then
+          if [[ ${{ matrix.php-version }} == '8.1' && ${{ matrix.db-type }} == 'sqlite' ]]; then
             vendor/bin/phpunit --coverage-clover=coverage.xml
           else
             vendor/bin/phpunit
@@ -76,7 +76,7 @@ jobs:
         run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
 
       - name: Code Coverage Report
-        if: success() && matrix.php-version == '7.4' && matrix.db-type == 'sqlite'
+        if: success() && matrix.php-version == '8.1' && matrix.db-type == 'sqlite'
         uses: codecov/codecov-action@v3
 
   validation:
@@ -89,7 +89,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -19,20 +19,20 @@
 		}
 	],
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"cakephp/cakephp": "^4.2.0"
 	},
 	"require-dev": {
 		"ext-intl": "*",
 		"ext-json": "*",
 		"geocoder-php/provider-implementation": "^1.0",
-		"php-http/cakephp-adapter": "^0.3.0",
-		"php-http/message": "^1.8.0",
+		"php-http/message": "^1.16.0",
 		"geocoder-php/google-maps-provider": "^4.4.0",
 		"geocoder-php/nominatim-provider": "^5.1",
 		"dereuromark/cakephp-tools": "^2.0.0",
 		"fig-r/psr2r-sniffer": "dev-master",
-		"phpunit/phpunit": "^9.5"
+		"phpunit/phpunit": "^9.5",
+		"symfony/http-client": "^6.0 || ^7.0"
 	},
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-geo"
@@ -48,6 +48,9 @@
 			"Geo\\Test\\": "tests/",
 			"TestApp\\": "tests/TestApp/src/"
 		}
+	},
+	"conflict": {
+		"php-http/cakephp-adapter": "*"
 	},
 	"scripts": {
 		"test": "phpunit",

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -39,12 +39,6 @@ Plugin::loadAll([
 ## Optional packages
 
 Depending on what tools you use (e.g. geocoding), you might need additional packages.
-So depending on the type of engine/adapter, you might need for example the following for geocoding:
-
-        "php-http/cakephp-adapter": "^0.3.0",
-        "php-http/message": "^1.8.0",
-        
-Add this to your composer.json require section then.
 
 For using GoogleMaps as concrete adapter, you might also need for example:
 

--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -4,7 +4,7 @@ namespace Geo\Geocoder;
 
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Http\Client as HttpCakeClient;
+use Cake\Http\Client;
 use Cake\I18n\I18n;
 use Geo\Exception\InconclusiveException;
 use Geo\Exception\NotAccurateEnoughException;
@@ -15,7 +15,6 @@ use Geocoder\Provider\GoogleMaps\GoogleMaps;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
 use Geocoder\StatefulGeocoder;
-use Http\Adapter\Cake\Client;
 use Locale;
 
 /**
@@ -129,7 +128,7 @@ class Geocoder {
 	protected $geocoder;
 
 	/**
-	 * @var \Http\Client\HttpClient
+	 * @var \Cake\Http\Client
 	 */
 	protected $adapter;
 
@@ -354,9 +353,9 @@ class Geocoder {
 			return;
 		}
 
-		/** @var \Http\Client\HttpClient $adapterClass */
+		/** @var \Cake\Http\Client $adapterClass */
 		$adapterClass = $this->getConfig('adapter');
-		$this->adapter = new $adapterClass(new HttpCakeClient(), new ResponseFactory());
+		$this->adapter = new $adapterClass();
 
 		$provider = new GoogleMaps($this->adapter, $this->getConfig('region'), $this->getConfig('apiKey'));
 		$geocoder = new StatefulGeocoder($provider, $this->getConfig('locale') ?: 'en');

--- a/src/Geocoder/Provider/GeoIpLookup.php
+++ b/src/Geocoder/Provider/GeoIpLookup.php
@@ -6,6 +6,7 @@
 
 namespace Geo\Geocoder\Provider;
 
+use Cake\Http\Client;
 use Cake\Utility\Xml;
 use Geocoder\Collection;
 use Geocoder\Exception\InvalidServerResponse;
@@ -16,7 +17,6 @@ use Geocoder\Model\AddressCollection;
 use Geocoder\Model\AdminLevel;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
-use Http\Client\HttpClient;
 
 /**
  * @author Mark Scherer
@@ -39,11 +39,11 @@ class GeoIpLookup extends AbstractHttpProvider {
 	protected $referer;
 
 	/**
-	 * @param \Http\Client\HttpClient $client an HTTP client
+	 * @param \Cake\Http\Client $client an HTTP client
 	 * @param string $userAgent Value of the User-Agent header
 	 * @param string $referer Value of the Referer header
 	 */
-	public function __construct(HttpClient $client, string $userAgent, string $referer = '') {
+	public function __construct(Client $client, string $userAgent, string $referer = '') {
 		parent::__construct($client);
 
 		$this->userAgent = $userAgent;

--- a/src/Geocoder/ResponseFactory.php
+++ b/src/Geocoder/ResponseFactory.php
@@ -3,14 +3,23 @@
 namespace Geo\Geocoder;
 
 use Cake\Http\Client\Response;
-use Http\Message\ResponseFactory as ResponseFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @deprecated Not in use anymore - directly use {@link \Cake\Http\Client} instead.
+ */
 class ResponseFactory implements ResponseFactoryInterface {
 
 	/**
-	 * @inheritDoc
+	 * @param int $code
+	 * @param string $reasonPhrase
+	 * @param array<string> $headers
+	 * @param string|null $body
+	 *
+	 * @return \Psr\Http\Message\ResponseInterface
 	 */
-	public function createResponse($statusCode = 200, $reasonPhrase = null, array $headers = [], $body = null, $protocolVersion = '1.1') {
+	public function createResponse(int $code = 200, string $reasonPhrase = '', array $headers = [], ?string $body = null): ResponseInterface {
 		return new Response($headers, (string)$body);
 	}
 

--- a/tests/TestCase/Geocoder/GeocoderTest.php
+++ b/tests/TestCase/Geocoder/GeocoderTest.php
@@ -2,11 +2,11 @@
 
 namespace Geo\Test\Geocoder;
 
+use Cake\Http\Client;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Geo\Geocoder\Provider\GeoIpLookup;
 use Geocoder\Provider\Nominatim\Nominatim;
-use Http\Adapter\Cake\Client;
 use TestApp\Geocoder\Geocoder;
 
 class GeocoderTest extends TestCase {

--- a/tests/TestCase/Geocoder/Provider/GeoIpLookupTest.php
+++ b/tests/TestCase/Geocoder/Provider/GeoIpLookupTest.php
@@ -2,10 +2,10 @@
 
 namespace Geo\Test\Geocoder;
 
+use Cake\Http\Client;
 use Cake\TestSuite\TestCase;
 use Geo\Geocoder\Provider\GeoIpAddress;
 use Geo\Geocoder\Provider\GeoIpLookup;
-use Http\Adapter\Cake\Client;
 
 class GeoIpLookupTest extends TestCase {
 

--- a/tests/TestCase/View/Helper/GoogleMapHelperTest.php
+++ b/tests/TestCase/View/Helper/GoogleMapHelperTest.php
@@ -235,7 +235,7 @@ class GoogleMapHelperTest extends TestCase {
 			'title' => '<b>Yeah!</b>',
 		];
 		$is = $this->GoogleMap->staticMap($options, $attr);
-		$expected = '<img src="//maps.google.com/maps/api/staticmap?size=200x100&amp;format=png&amp;mobile=false&amp;center=1&amp;maptype=roadmap" title="&lt;b&gt;Yeah!&lt;/b&gt;" alt="Map"/>';
+		$expected = '<img src="//maps.google.com/maps/api/staticmap?size=200x100&amp;format=png&amp;mobile=false&amp;center=1&amp;maptype=roadmap" title="&lt;b&gt;Yeah!&lt;/b&gt;" alt="Map">';
 		$this->assertSame($expected, $is);
 
 		$pos = [


### PR DESCRIPTION
I have prepared this PR based on yours. Please let me know if anything is missing or any change is required. I didnt included `geocoder-php/common-http` in composer as you did because I do not know if it is actually used or needed.

I have updated php requirements and github actions as well.

