### PR TITLE
Explore spatial support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         run: |
           sudo service mysql start
           mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp;'
+      - name: Setup Geography for PostgreSQL
+        if: matrix.db-type == 'pgsql'
+        run: |
+          sudo apt-get install postgis
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/docs/Behavior/Geocoder.md
+++ b/docs/Behavior/Geocoder.md
@@ -178,6 +178,4 @@ $query = $this->Addresses->find('spatial', [
 ```
 Note: This only works with PostGIS and MySQL 5.7+ (and MariaDB 10.4+) databases, as they support spatial data types.
 
-There can be a performance improvement when using spatial indexes, so you might want to consider using this for larger datasets.
-In reality I didnt get the index to work, though. Only managed to limit down the looked up entries from full table scan to range, which
-sped it up, too.
+The finder uses a bounding box pre-filter with `ST_Within()` to leverage spatial indexes, then refines results with `ST_Distance_Sphere()` for accurate distance calculations. This approach provides significant performance improvements on larger datasets.

--- a/docs/Behavior/Geocoder.md
+++ b/docs/Behavior/Geocoder.md
@@ -166,3 +166,18 @@ You can test the geocoding and also remove cache data where needed.
 
 ## Providers
 Full list of existing providers [here](https://github.com/geocoder-php/Geocoder#providers).
+
+## Spatial
+You can also use the "spatial" finder using coordinates as POINT instead of lat/lng.
+```php
+$query = $this->Addresses->find('spatial', [
+    'lat' => 13.3,
+    'lng' => 19.2,
+    'distance' => 100,
+]);
+```
+Note: This only works with PostGIS and MySQL 5.7+ (and MariaDB 10.4+) databases, as they support spatial data types.
+
+There can be a performance improvement when using spatial indexes, so you might want to consider using this for larger datasets.
+In reality I didnt get the index to work, though. Only managed to limit down the looked up entries from full table scan to range, which
+sped it up, too.

--- a/docs/Model/GeocodedAddresses.md
+++ b/docs/Model/GeocodedAddresses.md
@@ -16,6 +16,8 @@ You need to enable `Geo.GeocodedAddresses` Table. Just make sure you added the t
 bin/cake migrations migrate -p Geo
 ```
 
+Note: Configure `Geo.spatial` enables spatial functionality for this lookup table.
+
 Then instead of using the Geocoder class directly, you go through this Table:
 ```php
 $GeocodedAddresses = TableRegistry::getTableLocator()->get('Geo.GeocodedAddresses');

--- a/docs/Model/GeocodedAddresses.md
+++ b/docs/Model/GeocodedAddresses.md
@@ -16,8 +16,6 @@ You need to enable `Geo.GeocodedAddresses` Table. Just make sure you added the t
 bin/cake migrations migrate -p Geo
 ```
 
-Note: Configure `Geo.spatial` enables spatial functionality for this lookup table.
-
 Then instead of using the Geocoder class directly, you go through this Table:
 ```php
 $GeocodedAddresses = TableRegistry::getTableLocator()->get('Geo.GeocodedAddresses');
@@ -27,7 +25,7 @@ if ($address && $address->lat && $address->lng) {
 }
 ```
 
-Don't forget to add the Type mapping of `Geo\Database\Type\ObjectType` in your bootstrap.php.
+Remember to add the Type mapping of `Geo\Database\Type\ObjectType` in your bootstrap.php.
 ```php
 TypeFactory::map('object', 'Geo\Database\Type\ObjectType');
 ```

--- a/src/Controller/Admin/GeocodedAddressesController.php
+++ b/src/Controller/Admin/GeocodedAddressesController.php
@@ -9,7 +9,7 @@ use App\Controller\AppController;
  *
  * @property \Geo\Model\Table\GeocodedAddressesTable $GeocodedAddresses
  *
- * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress> paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress> paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, array $settings = [])
  */
 class GeocodedAddressesController extends AppController {
 

--- a/templates/Admin/GeocodedAddresses/index.php
+++ b/templates/Admin/GeocodedAddresses/index.php
@@ -1,10 +1,13 @@
 <?php
+
 /**
  * @var \App\View\AppView $this
- * @var \Geo\Model\Entity\GeocodedAddress[]|\Cake\Collection\CollectionInterface $geocodedAddresses
+ * @var iterable<\Geo\Model\Entity\GeocodedAddress> $geocodedAddresses
  */
+use Cake\Core\Plugin;
 
-use Cake\Core\Plugin; ?>
+?>
+
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
         <li class="heading"><?= __('Actions') ?></li>

--- a/tests/Fixture/SpatialAddressesFixture.php
+++ b/tests/Fixture/SpatialAddressesFixture.php
@@ -32,7 +32,6 @@ class SpatialAddressesFixture extends TestFixture {
 	 *
 	 * @var array
 	 */
-	public array $records = [
-	];
+	public array $records = [];
 
 }

--- a/tests/Fixture/SpatialAddressesFixture.php
+++ b/tests/Fixture/SpatialAddressesFixture.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Geo\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class SpatialAddressesFixture extends TestFixture {
+
+	/**
+	 * Fields
+	 *
+	 * @var array
+	 */
+	public array $fields = [
+		'id' => ['type' => 'integer'],
+		'address' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 190, 'comment' => 'street address and street numbe'],
+		'lat' => ['type' => 'float', 'null' => false, 'default' => null, 'comment' => 'maps.google.de latitude'],
+		'lng' => ['type' => 'float', 'null' => false, 'default' => null, 'comment' => 'maps.google.de longitude'],
+		'coordinates' => ['type' => 'point', 'null' => false],
+		'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
+		'modified' => ['type' => 'datetime', 'null' => true, 'default' => null],
+		'_constraints' => [
+			'primary' => ['type' => 'primary', 'columns' => ['id']],
+		],
+		'_indexes' => [
+			//'coordinates_spatial' => ['type' => 'spatial', 'columns' => ['coordinates'], 'length' => []],
+		],
+	];
+
+	/**
+	 * Records
+	 *
+	 * @var array
+	 */
+	public array $records = [
+	];
+
+}

--- a/tests/TestApp/src/Model/Table/SpatialAddressesTable.php
+++ b/tests/TestApp/src/Model/Table/SpatialAddressesTable.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace TestApp\Model\Table;
+
+use ArrayObject;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventInterface;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+
+/**
+ * GeocodedAddresses Model
+ *
+ * @method \Geo\Model\Entity\GeocodedAddress get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \Geo\Model\Entity\GeocodedAddress newEntity(array $data, array $options = [])
+ * @method array<\Geo\Model\Entity\GeocodedAddress> newEntities(array $data, array $options = [])
+ * @method \Geo\Model\Entity\GeocodedAddress|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \Geo\Model\Entity\GeocodedAddress patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method array<\Geo\Model\Entity\GeocodedAddress> patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Geo\Model\Entity\GeocodedAddress findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \Geo\Model\Entity\GeocodedAddress saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress>|false saveMany(iterable $entities, array $options = [])
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @method \Geo\Model\Entity\GeocodedAddress newEmptyEntity()
+ * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress> deleteManyOrFail(iterable $entities, array $options = [])
+ */
+class SpatialAddressesTable extends Table {
+
+	/**
+	 * @var \Geo\Geocoder\Geocoder
+	 */
+	protected $_Geocoder;
+
+	/**
+	 * Initialize method
+	 *
+	 * @param array<string, mixed> $config The configuration for the Table.
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->setTable('spatial_addresses');
+		$this->setDisplayField('address');
+		$this->setPrimaryKey('id');
+
+		//$this->getSchema()->setColumnType('data', 'object');
+
+		$this->addBehavior('Timestamp');
+	}
+
+	/**
+	 * Add formatter aka afterFind parsing geospatial values
+	 *
+	 * @param \Cake\Event\EventInterface $event
+	 * @param \Cake\ORM\Query\SelectQuery $query
+	 * @param \ArrayObject $options
+	 * @return void
+	 */
+	public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options): void {
+		$columns = ['coordinates' => 'point'];
+
+		// Go through each result and unpack() the binary data
+		$query->formatResults(function($results) use($columns) {
+			return $results->map(function($entity) use($columns) {
+				foreach ($columns as $column => $type) {
+					if (!isset($entity->{$column})) {
+						continue;
+					}
+					// [TypeError] unpack(): Argument #2 ($string) must be of type string
+					if (!is_string($entity->{$column})) {
+						continue;
+					}
+					switch ($type) {
+						// TODO support other types, not only POINT
+						case 'point':
+							$entity->{$column} = unpack('x/x/x/x/corder/Ltype/dx/dy', $entity->{$column});
+
+							break;
+					}
+				}
+
+				return $entity;
+			});
+		});
+	}
+
+	/**
+	 * Once entity is marshalled, prepare geospatial values to be saved into database
+	 *
+	 * @param \Cake\Event\EventInterface $event
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @param \ArrayObject $data
+	 * @param \ArrayObject $options
+	 * @return void
+	 */
+	public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {
+		$columns = ['coordinates' => 'point'];
+
+		foreach ($columns as $column => $type) {
+			// Skip if the column is not present in $data
+			if (!isset($data[$column])) {
+				if (!empty($data['lat']) && !empty($data['lng'])) {
+					$data[$column] = [$data['lng'], $data['lat']]; // lng, lat order is important!
+				} else {
+					continue;
+				}
+			}
+
+			// We expect an array like [12, 34] otherwise skip
+			if (!is_array($data[$column])) {
+				continue;
+			}
+			switch ($type) {
+				// TODO support other types, not only POINT
+				case 'point':
+					$value = sprintf('\'%s(%s)\'', strtoupper($type), implode(' ', $data[$column]));
+
+					break;
+			}
+			// Set $value on $entity using ST_GeomFromText()
+			$entity->{$column} = $this->query()->func()->ST_GeomFromText([
+				$value => 'literal',
+			]);
+		}
+	}
+
+}

--- a/tests/TestApp/src/Model/Table/SpatialAddressesTable.php
+++ b/tests/TestApp/src/Model/Table/SpatialAddressesTable.php
@@ -9,22 +9,22 @@ use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 
 /**
- * GeocodedAddresses Model
+ * SpatialAddresses Model
  *
- * @method \Geo\Model\Entity\GeocodedAddress get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \Geo\Model\Entity\GeocodedAddress newEntity(array $data, array $options = [])
- * @method array<\Geo\Model\Entity\GeocodedAddress> newEntities(array $data, array $options = [])
- * @method \Geo\Model\Entity\GeocodedAddress|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Geo\Model\Entity\GeocodedAddress patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Geo\Model\Entity\GeocodedAddress> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Geo\Model\Entity\GeocodedAddress findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \Geo\Model\Entity\GeocodedAddress saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress>|false saveMany(iterable $entities, array $options = [])
+ * @method \TestApp\Model\Entity\SpatialAddress get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \TestApp\Model\Entity\SpatialAddress newEntity(array $data, array $options = [])
+ * @method array<\TestApp\Model\Entity\SpatialAddress> newEntities(array $data, array $options = [])
+ * @method \TestApp\Model\Entity\SpatialAddress|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \TestApp\Model\Entity\SpatialAddress patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method array<\TestApp\Model\Entity\SpatialAddress> patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \TestApp\Model\Entity\SpatialAddress findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \TestApp\Model\Entity\SpatialAddress saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\SpatialAddress>|false saveMany(iterable $entities, array $options = [])
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @method \Geo\Model\Entity\GeocodedAddress newEmptyEntity()
- * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Geo\Model\Entity\GeocodedAddress> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \TestApp\Model\Entity\SpatialAddress newEmptyEntity()
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\SpatialAddress> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\SpatialAddress>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\SpatialAddress> deleteManyOrFail(iterable $entities, array $options = [])
  */
 class SpatialAddressesTable extends Table {
 
@@ -46,7 +46,7 @@ class SpatialAddressesTable extends Table {
 		$this->setDisplayField('address');
 		$this->setPrimaryKey('id');
 
-		//$this->getSchema()->setColumnType('data', 'object');
+		//$this->getSchema()->setColumnType('coordinates', 'point');
 
 		$this->addBehavior('Timestamp');
 	}

--- a/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
+++ b/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
@@ -105,8 +105,6 @@ class SpatialAddressesTableTest extends TestCase {
 	 * @return void
 	 */
 	public function testFindSpatial() {
-		$this->assertNotEmpty($this->SpatialAddresses->getSchema()->getIndex('coordinates_spatial'));
-
 		$this->SpatialAddresses->addBehavior('Geo.Geocoder');
 		$addresses = $this->SpatialAddresses->find('spatial', ...[
 			'lat' => 48.110589,

--- a/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
+++ b/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
@@ -28,11 +28,11 @@ class SpatialAddressesTableTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		$db = ConnectionManager::get('test');
 		$driver = $db->getDriver();
 		$this->skipIf(!($driver instanceof Mysql), 'The functionality/test is only compatible with Mysql right now.');
+
+		parent::setUp();
 
 		$config = TableRegistry::getTableLocator()->exists('SpatialAddresses') ? [] : ['className' => 'TestApp\Model\Table\SpatialAddressesTable'];
 		$this->SpatialAddresses = TableRegistry::getTableLocator()->get('SpatialAddresses', $config);

--- a/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
+++ b/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
@@ -3,7 +3,6 @@
 namespace Geo\Test\TestCase\Model\Table;
 
 use Cake\Database\Driver\Mysql;
-use Cake\Database\Driver\Postgres;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
+++ b/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Geo\Test\TestCase\Model\Table;
+
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+
+class SpatialAddressesTableTest extends TestCase {
+
+	/**
+	 * Fixtures
+	 *
+	 * @var array
+	 */
+	protected array $fixtures = [
+		'plugin.Geo.SpatialAddresses',
+	];
+
+	/**
+	 * @var \TestApp\Model\Table\SpatialAddressesTable
+	 */
+	protected $SpatialAddresses;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$db = ConnectionManager::get('test');
+		$driver = $db->getDriver();
+		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
+
+		$config = TableRegistry::getTableLocator()->exists('SpatialAddresses') ? [] : ['className' => 'TestApp\Model\Table\SpatialAddressesTable'];
+		$this->SpatialAddresses = TableRegistry::getTableLocator()->get('SpatialAddresses', $config);
+
+		$entries = [
+			[
+				'address' => 'Langstrasse 10, 101010 München',
+				'lat' => '48.150589',
+				'lng' => '11.472230',
+				'created' => '2011-04-21 16:50:05',
+				'modified' => '2011-10-07 17:42:27',
+			],
+			[
+				'address' => 'Leckermannstrasse 10, 10101 München',
+				'lat' => '48.133942',
+				'lng' => '11.490000',
+				'created' => '2011-04-21 16:51:01',
+				'modified' => '2011-10-07 17:44:02',
+			],
+			[
+				'address' => 'Krebenweg 11, 12523 Schwäbisch Hall',
+				'lat' => '19.081490',
+				'lng' => '19.690800',
+				'created' => '2011-11-17 13:47:36',
+				'modified' => '2011-11-17 13:47:36',
+			],
+			[
+				'address' => 'hjsf',
+				'lat' => '52.52',
+				'lng' => '13.40',
+				'created' => '2011-11-17 14:34:14',
+				'modified' => '2011-11-17 14:49:21',
+			],
+		];
+		foreach ($entries as $entry) {
+			$entity = $this->SpatialAddresses->newEntity($entry);
+			$this->SpatialAddresses->saveOrFail($entity);
+		}
+
+		//debug($this->SpatialAddresses->getSchema()->getIndex('coordinates_spatial'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		unset($this->SpatialAddresses);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSave() {
+		$address = $this->SpatialAddresses->newEntity([
+			'address' => 'Berlin',
+			'lat' => 12,
+			'lng' => 11,
+		]);
+		$address = $this->SpatialAddresses->save($address);
+		$this->assertNotEmpty($address);
+
+		$address = $this->SpatialAddresses->get($address->id);
+		$this->assertNotEmpty($address->coordinates);
+		$this->assertEquals(11, $address->coordinates['x']);
+		$this->assertEquals(12, $address->coordinates['y']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindSpatial() {
+		$this->SpatialAddresses->addBehavior('Geo.Geocoder');
+		$addresses = $this->SpatialAddresses->find('spatial', ...[
+			'lat' => 48.110589,
+			'lng' => 11.422230,
+			'distance' => 100,
+		])
+			->all()
+			->toArray();
+
+		$distances = Hash::extract($addresses, '{n}.distance');
+		$expeected = [
+			5.66,
+			5.79,
+		];
+		foreach ($distances as $key => $distance) {
+			$this->assertSame($expeected[$key], round($distance, 2));
+		}
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -103,6 +103,17 @@ Configure::write('Geocoder', [
 	'apiKey' => env('API_KEY'), // local, set through `export API_KEY=".."` in CLI
 ]);
 
+/**
+ * @var \Cake\Database\Connection $db
+ */
+$db = ConnectionManager::get('test');
+if ($db->getDriver() instanceof \Cake\Database\Driver\Postgres) {
+	//$db->execute('CREATE EXTENSION postgis;');
+}
+if ($db->getDriver() instanceof \Cake\Database\Driver\Mysql) {
+	$db->execute('ALTER TABLE spatial_addresses ADD SPATIAL INDEX coordinates_spatial(coordinates);');
+}
+
 if (env('FIXTURE_SCHEMA_METADATA')) {
 	$loader = new SchemaLoader();
 	$loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -108,7 +108,7 @@ Configure::write('Geocoder', [
  */
 $db = ConnectionManager::get('test');
 if ($db->getDriver() instanceof \Cake\Database\Driver\Postgres) {
-	//$db->execute('CREATE EXTENSION postgis;');
+	$db->execute('CREATE EXTENSION postgis;');
 }
 
 if (env('FIXTURE_SCHEMA_METADATA')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,11 +110,12 @@ $db = ConnectionManager::get('test');
 if ($db->getDriver() instanceof \Cake\Database\Driver\Postgres) {
 	//$db->execute('CREATE EXTENSION postgis;');
 }
-if ($db->getDriver() instanceof \Cake\Database\Driver\Mysql) {
-	$db->execute('ALTER TABLE spatial_addresses ADD SPATIAL INDEX coordinates_spatial(coordinates);');
-}
 
 if (env('FIXTURE_SCHEMA_METADATA')) {
 	$loader = new SchemaLoader();
 	$loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));
+}
+
+if ($db->getDriver() instanceof \Cake\Database\Driver\Mysql) {
+	$db->execute('ALTER TABLE spatial_addresses ADD SPATIAL INDEX coordinates_spatial(coordinates);');
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,9 @@
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Exception\QueryException;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use Cake\View\View;
@@ -107,7 +110,7 @@ Configure::write('Geocoder', [
  * @var \Cake\Database\Connection $db
  */
 $db = ConnectionManager::get('test');
-if ($db->getDriver() instanceof \Cake\Database\Driver\Postgres) {
+if ($db->getDriver() instanceof Postgres) {
 	//$db->execute('CREATE EXTENSION postgis;')->fetchAll();
 	//debug($db->execute('SELECT postgis_full_version();')->fetchAssoc());
 }
@@ -117,10 +120,10 @@ if (env('FIXTURE_SCHEMA_METADATA')) {
 	$loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));
 }
 
-if ($db->getDriver() instanceof \Cake\Database\Driver\Mysql) {
+if ($db->getDriver() instanceof Mysql) {
 	try {
 		$db->execute('ALTER TABLE spatial_addresses ADD SPATIAL INDEX coordinates_spatial(coordinates);');
-	} catch (\Cake\Database\Exception\QueryException) {
+	} catch (QueryException) {
 		// Index already exists
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -108,7 +108,9 @@ Configure::write('Geocoder', [
  */
 $db = ConnectionManager::get('test');
 if ($db->getDriver() instanceof \Cake\Database\Driver\Postgres) {
-	$db->execute('CREATE EXTENSION postgis;');
+	$db->execute('CREATE EXTENSION postgis;')->fetchAll();
+
+	debug($db->execute('SELECT postgis_full_version();')->fetchAssoc());
 }
 
 if (env('FIXTURE_SCHEMA_METADATA')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -118,5 +118,9 @@ if (env('FIXTURE_SCHEMA_METADATA')) {
 }
 
 if ($db->getDriver() instanceof \Cake\Database\Driver\Mysql) {
-	$db->execute('ALTER TABLE spatial_addresses ADD SPATIAL INDEX coordinates_spatial(coordinates);');
+	try {
+		$db->execute('ALTER TABLE spatial_addresses ADD SPATIAL INDEX coordinates_spatial(coordinates);');
+	} catch (\Cake\Database\Exception\QueryException) {
+		// Index already exists
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -108,9 +108,8 @@ Configure::write('Geocoder', [
  */
 $db = ConnectionManager::get('test');
 if ($db->getDriver() instanceof \Cake\Database\Driver\Postgres) {
-	$db->execute('CREATE EXTENSION postgis;')->fetchAll();
-
-	debug($db->execute('SELECT postgis_full_version();')->fetchAssoc());
+	//$db->execute('CREATE EXTENSION postgis;')->fetchAll();
+	//debug($db->execute('SELECT postgis_full_version();')->fetchAssoc());
 }
 
 if (env('FIXTURE_SCHEMA_METADATA')) {

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -33,6 +33,10 @@ foreach ($iterator as $file) {
 		'indexes' => $indexes,
 	];
 	$tables[$tableName] = $table;
+
+	if (str_contains(getenv('DB_URL'), 'postgres')) {
+		unset($tables['spatial_addresses']);
+	}
 }
 
 return $tables;


### PR DESCRIPTION
The whole idea of spatial lookups/filtering is that it should be able to use an index and avoid full table scans.
```
[
  'id' => (int) 1,
  'select_type' => 'SIMPLE',
  'table' => 'SpatialAddresses',
  'partitions' => null,
  'type' => 'ALL', // !!!
  'possible_keys' => null,
  'key' => null,
  'key_len' => null,
  'ref' => null,
  'rows' => (int) 4,
  'filtered' => (float) 100,
  'Extra' => 'Using where; Using filesort'
]
```