### PR TITLE
Add LeafletHelper as open-source alternative to GoogleMapHelper

### DIFF
--- a/docs/Helper/Leaflet.md
+++ b/docs/Helper/Leaflet.md
@@ -1,0 +1,277 @@
+# Leaflet Helper
+Using [Leaflet.js](https://leafletjs.com/) - an open-source JavaScript library for interactive maps.
+
+## Adding the helper
+
+Either in your View class or at runtime:
+```php
+$config = [
+    'autoScript' => true,
+];
+$this->loadHelper('Geo.Leaflet', $config);
+```
+
+You can easily configure this globally using Configure (e.g. config/app.php):
+```php
+    'Leaflet' => [
+        'zoom' => 10,
+        'lat' => 48.2082,
+        'lng' => 16.3738,
+    ],
+```
+
+Possible config options are:
+- zoom: Uses the defaultZoom of 5 otherwise
+- lat/lng: Default center coordinates
+- block: Display defaults to true to append the generated JS to the "scripts" block
+- map: Multiple map options (scrollWheelZoom, zoomControl, dragging)
+- tileLayer: Tile layer URL and options
+- div: Multiple div options (id, width, height, class)
+- marker: Multiple marker options
+- popup: Multiple popup options
+- polyline: Polyline styling options
+- circle: Circle styling options
+- polygon: Polygon styling options
+- autoCenter: Automatically fit bounds to all markers
+- autoScript: Auto-include Leaflet JS/CSS from CDN
+
+## Display a basic dynamic map
+Make sure you either loaded your helper with autoScript enabled, or you manually include the Leaflet CSS and JS files.
+
+```php
+$options = [
+    'zoom' => 13,
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+];
+$map = $this->Leaflet->map($options);
+
+// You can echo it now anywhere, it does not matter if you add markers afterwards
+echo $map;
+
+// Let's add some markers
+$this->Leaflet->addMarker([
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'title' => 'Vienna',
+    'content' => 'Welcome to <b>Vienna</b>!',
+]);
+
+$this->Leaflet->addMarker([
+    'lat' => 48.1951,
+    'lng' => 16.3715,
+    'title' => 'Belvedere',
+    'content' => 'The Belvedere Palace',
+]);
+
+// Store the final JS in a HtmlHelper script block
+$this->Leaflet->finalize();
+```
+Don't forget to output the buffered JS at the end of your page, where also the other files are included (after all JS files are included!):
+```php
+echo $this->fetch('script');
+```
+This code snippet is usually already in your `layout.php` at the end of the body tag.
+
+### Inline JS
+Maybe you need inline JS instead, then you can call script() instead of finalize() directly:
+```php
+// Initialize
+$map = $this->Leaflet->map();
+
+// Add markers and stuff
+$this->Leaflet->addMarker([...]);
+
+// Finalize
+$map .= $this->Leaflet->script();
+
+// Output both together
+echo $map;
+```
+
+## Adding markers with popups
+```php
+// Simple marker
+$this->Leaflet->addMarker([
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'title' => 'Vienna',
+]);
+
+// Marker with popup content
+$this->Leaflet->addMarker([
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'content' => '<b>Vienna</b><br>Capital of Austria',
+]);
+
+// Marker with popup open by default
+$this->Leaflet->addMarker([
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'content' => 'This popup is open!',
+    'open' => true,
+]);
+
+// Draggable marker
+$this->Leaflet->addMarker([
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'draggable' => true,
+]);
+```
+
+## Tile Providers
+The helper comes with built-in tile provider presets:
+
+```php
+// OpenStreetMap (default)
+$this->Leaflet->useTilePreset(\Geo\View\Helper\LeafletHelper::TILES_OSM);
+
+// CartoDB Light
+$this->Leaflet->useTilePreset(\Geo\View\Helper\LeafletHelper::TILES_CARTO_LIGHT);
+
+// CartoDB Dark
+$this->Leaflet->useTilePreset(\Geo\View\Helper\LeafletHelper::TILES_CARTO_DARK);
+
+// Then create your map
+$map = $this->Leaflet->map();
+```
+
+### Custom tile layer
+You can also add custom tile layers:
+```php
+$this->Leaflet->map();
+$this->Leaflet->addTileLayer(
+    'https://{s}.custom-tiles.com/{z}/{x}/{y}.png',
+    ['attribution' => '&copy; Custom Tiles']
+);
+```
+
+## Drawing shapes
+
+### Polyline
+```php
+$this->Leaflet->addPolyline(
+    ['lat' => 48.2082, 'lng' => 16.3738],
+    ['lat' => 47.0707, 'lng' => 15.4395],
+    ['color' => '#ff0000', 'weight' => 5]
+);
+
+// Or from multiple points
+$points = [
+    ['lat' => 48.2082, 'lng' => 16.3738],
+    ['lat' => 47.0707, 'lng' => 15.4395],
+    ['lat' => 46.0569, 'lng' => 14.5058],
+];
+$this->Leaflet->addPolylineFromPoints($points, ['color' => '#00ff00']);
+```
+
+### Circle
+```php
+$this->Leaflet->addCircle([
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'radius' => 5000,  // meters
+    'color' => '#3388ff',
+    'fillColor' => '#3388ff',
+    'fillOpacity' => 0.2,
+]);
+```
+
+### Polygon
+```php
+$points = [
+    ['lat' => 48.2, 'lng' => 16.3],
+    ['lat' => 48.3, 'lng' => 16.4],
+    ['lat' => 48.1, 'lng' => 16.5],
+];
+$this->Leaflet->addPolygon($points, [
+    'color' => '#ff0000',
+    'fillOpacity' => 0.5,
+]);
+```
+
+## GeoJSON support
+```php
+$geoJson = [
+    'type' => 'FeatureCollection',
+    'features' => [
+        [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [16.3738, 48.2082],
+            ],
+            'properties' => [
+                'name' => 'Vienna',
+            ],
+        ],
+    ],
+];
+$this->Leaflet->addGeoJson($geoJson);
+```
+
+## Multiple maps per page
+The helper automatically resets when you call `map()`. Each map gets a unique counter:
+
+```php
+// First map
+echo $this->Leaflet->map(['div' => ['id' => 'map1']]);
+$this->Leaflet->addMarker(['lat' => 48.2, 'lng' => 16.3]);
+$this->Leaflet->finalize();
+
+// Second map
+echo $this->Leaflet->map(['div' => ['id' => 'map2']]);
+$this->Leaflet->addMarker(['lat' => 47.0, 'lng' => 15.4]);
+$this->Leaflet->finalize();
+```
+
+## Auto-centering
+To automatically fit the map bounds to include all markers:
+
+```php
+$map = $this->Leaflet->map(['autoCenter' => true]);
+
+$this->Leaflet->addMarker(['lat' => 48.2, 'lng' => 16.3]);
+$this->Leaflet->addMarker(['lat' => 47.0, 'lng' => 15.4]);
+$this->Leaflet->addMarker(['lat' => 46.0, 'lng' => 14.5]);
+
+$this->Leaflet->finalize();
+```
+
+## Custom JS
+With `->addCustom($js)` you can inject any custom JS to work alongside the Leaflet helper code:
+
+```php
+$this->Leaflet->map();
+$this->Leaflet->addCustom('
+    map0.on("click", function(e) {
+        alert("You clicked at " + e.latlng);
+    });
+');
+$this->Leaflet->finalize();
+```
+
+## Map options
+You can configure various Leaflet map options:
+
+```php
+$options = [
+    'zoom' => 13,
+    'lat' => 48.2082,
+    'lng' => 16.3738,
+    'map' => [
+        'scrollWheelZoom' => false,  // Disable scroll wheel zoom
+        'zoomControl' => true,        // Show zoom controls
+        'dragging' => true,           // Allow map dragging
+    ],
+    'div' => [
+        'id' => 'my-map',
+        'width' => '800px',
+        'height' => '600px',
+        'class' => 'custom-map-class',
+    ],
+];
+$map = $this->Leaflet->map($options);
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 * [Calculator lib](Geocoder/Calculator.md)
 * [Geo lib](Geocoder/Geo.md)
 * [GoogleMap helper](Helper/GoogleMap.md)
+* [Leaflet helper](Helper/Leaflet.md)
 * [GeocodedAddresses result cache](Model/GeocodedAddresses.md)
 
 ## Contributing

--- a/src/View/Helper/LeafletHelper.php
+++ b/src/View/Helper/LeafletHelper.php
@@ -1,0 +1,727 @@
+<?php
+
+namespace Geo\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\Utility\Hash;
+use Cake\View\Helper;
+
+/**
+ * This is a CakePHP helper that helps users to integrate Leaflet.js
+ * into their application by only writing PHP code. This helper depends on jQuery.
+ *
+ * Capable of resetting itself (full or partly) for multiple maps on a single view.
+ *
+ * @link https://leafletjs.com/
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @property \Cake\View\Helper\HtmlHelper $Html
+ */
+class LeafletHelper extends Helper {
+
+	use JsBaseEngineTrait;
+
+	/**
+	 * OpenStreetMap tiles
+	 *
+	 * @var string
+	 */
+	public const TILES_OSM = 'osm';
+
+	/**
+	 * CartoDB Light tiles
+	 *
+	 * @var string
+	 */
+	public const TILES_CARTO_LIGHT = 'carto_light';
+
+	/**
+	 * CartoDB Dark tiles
+	 *
+	 * @var string
+	 */
+	public const TILES_CARTO_DARK = 'carto_dark';
+
+	/**
+	 * @var int
+	 */
+	public static int $mapCount = 0;
+
+	/**
+	 * @var int
+	 */
+	public static int $markerCount = 0;
+
+	/**
+	 * @var int
+	 */
+	public static int $popupCount = 0;
+
+	/**
+	 * Needed helpers
+	 *
+	 * @var array
+	 */
+	protected array $helpers = ['Html'];
+
+	/**
+	 * Markers array
+	 *
+	 * @var array
+	 */
+	public array $markers = [];
+
+	/**
+	 * Popups array
+	 *
+	 * @var array
+	 */
+	public array $popups = [];
+
+	/**
+	 * Current map JS
+	 *
+	 * @var string
+	 */
+	public string $map = '';
+
+	/**
+	 * Tile layer presets
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	protected array $tilePresets = [
+		'osm' => [
+			'url' => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			'options' => [
+				'attribution' => '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+				'maxZoom' => 19,
+			],
+		],
+		'carto_light' => [
+			'url' => 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+			'options' => [
+				'attribution' => '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>',
+				'maxZoom' => 20,
+				'subdomains' => 'abcd',
+			],
+		],
+		'carto_dark' => [
+			'url' => 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+			'options' => [
+				'attribution' => '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>',
+				'maxZoom' => 20,
+				'subdomains' => 'abcd',
+			],
+		],
+	];
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $_mapIds = [];
+
+	/**
+	 * Default settings
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'zoom' => null,
+		'lat' => null,
+		'lng' => null,
+		'map' => [
+			'zoom' => null,
+			'lat' => null,
+			'lng' => null,
+			'scrollWheelZoom' => true,
+			'zoomControl' => true,
+			'dragging' => true,
+			'defaultLat' => 51,
+			'defaultLng' => 11,
+			'defaultZoom' => 5,
+		],
+		'tileLayer' => [
+			'url' => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			'options' => [
+				'attribution' => '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+				'maxZoom' => 19,
+			],
+		],
+		'marker' => [
+			'draggable' => false,
+			'title' => null,
+			'open' => false,
+		],
+		'popup' => [
+			'content' => '',
+			'maxWidth' => 300,
+			'autoClose' => true,
+		],
+		'polyline' => [
+			'color' => '#3388ff',
+			'weight' => 3,
+			'opacity' => 1.0,
+		],
+		'circle' => [
+			'color' => '#3388ff',
+			'fillColor' => '#3388ff',
+			'fillOpacity' => 0.2,
+			'radius' => 500,
+		],
+		'polygon' => [
+			'color' => '#3388ff',
+			'fillColor' => '#3388ff',
+			'fillOpacity' => 0.2,
+		],
+		'div' => [
+			'id' => 'map',
+			'width' => '100%',
+			'height' => '400px',
+			'class' => 'leaflet-map',
+		],
+		'autoCenter' => false,
+		'autoScript' => false,
+		'block' => true,
+	];
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_runtimeConfig = [];
+
+	/**
+	 * @var bool
+	 */
+	protected bool $_apiIncluded = false;
+
+	/**
+	 * @param array<string, mixed> $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$defaultConfig = Hash::merge($this->_defaultConfig, (array)Configure::read('Leaflet'));
+		$config = Hash::merge($defaultConfig, $config);
+
+		if (isset($config['zoom']) && !isset($config['map']['zoom'])) {
+			$config['map']['zoom'] = $config['zoom'];
+		}
+		if (isset($config['lat']) && !isset($config['map']['lat'])) {
+			$config['map']['lat'] = $config['lat'];
+		}
+		if (isset($config['lng']) && !isset($config['map']['lng'])) {
+			$config['map']['lng'] = $config['lng'];
+		}
+		if (isset($config['size'])) {
+			$config['div']['width'] = $config['size']['width'];
+			$config['div']['height'] = $config['size']['height'];
+		}
+
+		$this->_config = $config;
+		$this->_runtimeConfig = $this->_config;
+	}
+
+	/**
+	 * @return string currentMapObject
+	 */
+	public function name(): string {
+		return 'map' . static::$mapCount;
+	}
+
+	/**
+	 * @return string currentContainerId
+	 */
+	public function id(): string {
+		return $this->_runtimeConfig['div']['id'];
+	}
+
+	/**
+	 * Make it possible to include multiple maps per page
+	 * resets markers, popups etc
+	 *
+	 * @param bool $full true=optionsAsWell
+	 * @return void
+	 */
+	public function reset(bool $full = true): void {
+		static::$markerCount = static::$popupCount = 0;
+		$this->markers = $this->popups = [];
+		if ($full) {
+			$this->_runtimeConfig = $this->_config;
+		}
+	}
+
+	/**
+	 * Use a predefined tile provider preset.
+	 *
+	 * @param string $preset Preset name (osm, carto_light, carto_dark)
+	 * @return void
+	 */
+	public function useTilePreset(string $preset): void {
+		if (!isset($this->tilePresets[$preset])) {
+			return;
+		}
+		$this->_config['tileLayer'] = $this->tilePresets[$preset];
+		$this->_runtimeConfig['tileLayer'] = $this->tilePresets[$preset];
+	}
+
+	/**
+	 * This the initialization point of the script.
+	 * Returns the div container you can echo on the website.
+	 *
+	 * @param array<string, mixed> $options associative array of settings are passed
+	 * @return string divContainer
+	 */
+	public function map(array $options = []): string {
+		$this->reset();
+		$this->_runtimeConfig = Hash::merge($this->_runtimeConfig, $options);
+		$this->_runtimeConfig['map'] = $options + $this->_runtimeConfig['map'];
+
+		if (!isset($this->_runtimeConfig['map']['lat']) || !isset($this->_runtimeConfig['map']['lng'])) {
+			$this->_runtimeConfig['map']['lat'] = $this->_runtimeConfig['map']['defaultLat'];
+			$this->_runtimeConfig['map']['lng'] = $this->_runtimeConfig['map']['defaultLng'];
+		}
+		if (!isset($this->_runtimeConfig['map']['zoom'])) {
+			$this->_runtimeConfig['map']['zoom'] = $this->_runtimeConfig['map']['defaultZoom'];
+		}
+
+		$result = '';
+
+		// autoinclude js/css?
+		if ($this->_runtimeConfig['autoScript'] && !$this->_apiIncluded) {
+			$cssUrl = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+			$jsUrl = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+
+			$css = $this->Html->css($cssUrl, ['block' => $this->_runtimeConfig['block']]);
+			$js = $this->Html->script($jsUrl, ['block' => $this->_runtimeConfig['block']]);
+			$this->_apiIncluded = true;
+
+			if (!$this->_runtimeConfig['block']) {
+				$result .= $css . PHP_EOL . $js . PHP_EOL;
+			}
+		}
+
+		// Rename div id if already used
+		while (in_array($this->_runtimeConfig['div']['id'], $this->_mapIds, true)) {
+			$this->_runtimeConfig['div']['id'] .= '-1';
+		}
+		$this->_mapIds[] = $this->_runtimeConfig['div']['id'];
+
+		$map = '
+		var lMarkers' . static::$mapCount . ' = [];
+		var lPopups' . static::$mapCount . ' = [];
+		';
+
+		$map .= '
+		var ' . $this->name() . ' = L.map("' . $this->_runtimeConfig['div']['id'] . '", ' . $this->_mapOptions() . ');
+		' . $this->name() . '.setView([' . $this->_runtimeConfig['map']['lat'] . ', ' . $this->_runtimeConfig['map']['lng'] . '], ' . $this->_runtimeConfig['map']['zoom'] . ');
+		';
+
+		$map .= $this->_tileLayerJs();
+
+		$this->map = $map;
+
+		// Build div attributes
+		$divOptions = $this->_runtimeConfig['div'];
+		$divOptions['style'] = '';
+		if (is_numeric($divOptions['width'])) {
+			$divOptions['width'] .= 'px';
+		}
+		if (is_numeric($divOptions['height'])) {
+			$divOptions['height'] .= 'px';
+		}
+
+		$divOptions['style'] .= 'width: ' . $divOptions['width'] . ';';
+		$divOptions['style'] .= 'height: ' . $divOptions['height'] . ';';
+		unset($divOptions['width'], $divOptions['height']);
+
+		$defaultText = $this->_runtimeConfig['content'] ?? __('Map cannot be displayed!');
+		$result .= $this->Html->tag('div', $defaultText, $divOptions);
+
+		return $result;
+	}
+
+	/**
+	 * Add a marker to the map.
+	 *
+	 * Options:
+	 * - lat and lng (required)
+	 * - title, content, icon, draggable, open (optional)
+	 *
+	 * @param array<string, mixed> $options
+	 * @return int marker count
+	 */
+	public function addMarker(array $options): int {
+		$defaults = $this->_runtimeConfig['marker'];
+		$options += $defaults;
+
+		$markerOptions = [];
+		if (isset($options['title'])) {
+			$markerOptions['title'] = $options['title'];
+		}
+		if (isset($options['draggable']) && $options['draggable']) {
+			$markerOptions['draggable'] = true;
+		}
+		if (isset($options['icon'])) {
+			$markerOptions['icon'] = $options['icon'];
+		}
+
+		$position = '[' . $options['lat'] . ', ' . $options['lng'] . ']';
+
+		$markerOptionsJs = '';
+		if ($markerOptions) {
+			$markerOptionsJs = ', ' . $this->_buildJsObject($markerOptions);
+		}
+
+		$marker = '
+		var x' . static::$markerCount . ' = L.marker(' . $position . $markerOptionsJs . ').addTo(' . $this->name() . ');
+		lMarkers' . static::$mapCount . '.push(x' . static::$markerCount . ');
+		';
+
+		if (!empty($options['content'])) {
+			$marker .= 'x' . static::$markerCount . '.bindPopup(' . $this->escapeString($options['content']) . ');
+			';
+			if (!empty($options['open'])) {
+				$marker .= 'x' . static::$markerCount . '.openPopup();
+				';
+			}
+		}
+
+		$this->map .= $marker;
+		$this->markers[static::$markerCount] = $marker;
+
+		return static::$markerCount++;
+	}
+
+	/**
+	 * Add a standalone popup to the map.
+	 *
+	 * @param array<string, mixed> $options
+	 * @return int popup count
+	 */
+	public function addPopup(array $options = []): int {
+		$defaults = $this->_runtimeConfig['popup'];
+		$options += $defaults;
+
+		$popupOptions = [];
+		if (isset($options['maxWidth'])) {
+			$popupOptions['maxWidth'] = $options['maxWidth'];
+		}
+		if (isset($options['autoClose'])) {
+			$popupOptions['autoClose'] = $options['autoClose'];
+		}
+
+		$position = '[' . $options['lat'] . ', ' . $options['lng'] . ']';
+
+		$popupOptionsJs = '';
+		if ($popupOptions) {
+			$popupOptionsJs = $this->_buildJsObject($popupOptions);
+		}
+
+		$popup = '
+		var p' . static::$popupCount . ' = L.popup(' . $popupOptionsJs . ')
+			.setLatLng(' . $position . ')
+			.setContent(' . $this->escapeString($options['content']) . ')
+			.openOn(' . $this->name() . ');
+		lPopups' . static::$mapCount . '.push(p' . static::$popupCount . ');
+		';
+
+		$this->map .= $popup;
+		$this->popups[static::$popupCount] = $popup;
+
+		return static::$popupCount++;
+	}
+
+	/**
+	 * Add a polyline between two or more points.
+	 *
+	 * @param array|string $from Location as array(lat, lng pair)
+	 * @param array|string $to Location as array(lat, lng pair)
+	 * @param array<string, mixed> $options
+	 * @return void
+	 */
+	public function addPolyline(array|string $from, array|string $to, array $options = []): void {
+		$defaults = $this->_runtimeConfig['polyline'];
+		$options += $defaults;
+
+		$points = [];
+		if (is_array($from)) {
+			$points[] = '[' . (float)$from['lat'] . ', ' . (float)$from['lng'] . ']';
+		}
+		if (is_array($to)) {
+			$points[] = '[' . (float)$to['lat'] . ', ' . (float)$to['lng'] . ']';
+		}
+
+		$polylineOptions = [
+			'color' => $options['color'],
+			'weight' => $options['weight'],
+			'opacity' => $options['opacity'],
+		];
+
+		$polyline = '
+		L.polyline([' . implode(', ', $points) . '], ' . $this->_buildJsObject($polylineOptions) . ').addTo(' . $this->name() . ');
+		';
+
+		$this->map .= $polyline;
+	}
+
+	/**
+	 * Add a polyline from an array of points.
+	 *
+	 * @param array<array<string, float>> $points Array of lat/lng pairs
+	 * @param array<string, mixed> $options
+	 * @return void
+	 */
+	public function addPolylineFromPoints(array $points, array $options = []): void {
+		$defaults = $this->_runtimeConfig['polyline'];
+		$options += $defaults;
+
+		$jsPoints = [];
+		foreach ($points as $point) {
+			$jsPoints[] = '[' . (float)$point['lat'] . ', ' . (float)$point['lng'] . ']';
+		}
+
+		$polylineOptions = [
+			'color' => $options['color'],
+			'weight' => $options['weight'],
+			'opacity' => $options['opacity'],
+		];
+
+		$polyline = '
+		L.polyline([' . implode(', ', $jsPoints) . '], ' . $this->_buildJsObject($polylineOptions) . ').addTo(' . $this->name() . ');
+		';
+
+		$this->map .= $polyline;
+	}
+
+	/**
+	 * Add a circle to the map.
+	 *
+	 * @param array<string, mixed> $options
+	 * @return void
+	 */
+	public function addCircle(array $options): void {
+		$defaults = $this->_runtimeConfig['circle'];
+		$options += $defaults;
+
+		$position = '[' . (float)$options['lat'] . ', ' . (float)$options['lng'] . ']';
+
+		$circleOptions = [
+			'color' => $options['color'],
+			'fillColor' => $options['fillColor'],
+			'fillOpacity' => $options['fillOpacity'],
+			'radius' => $options['radius'],
+		];
+
+		$circle = '
+		L.circle(' . $position . ', ' . $this->_buildJsObject($circleOptions) . ').addTo(' . $this->name() . ');
+		';
+
+		$this->map .= $circle;
+	}
+
+	/**
+	 * Add a polygon to the map.
+	 *
+	 * @param array<array<string, float>> $points Array of lat/lng pairs
+	 * @param array<string, mixed> $options
+	 * @return void
+	 */
+	public function addPolygon(array $points, array $options = []): void {
+		$defaults = $this->_runtimeConfig['polygon'];
+		$options += $defaults;
+
+		$jsPoints = [];
+		foreach ($points as $point) {
+			$jsPoints[] = '[' . (float)$point['lat'] . ', ' . (float)$point['lng'] . ']';
+		}
+
+		$polygonOptions = [
+			'color' => $options['color'],
+			'fillColor' => $options['fillColor'],
+			'fillOpacity' => $options['fillOpacity'],
+		];
+
+		$polygon = '
+		L.polygon([' . implode(', ', $jsPoints) . '], ' . $this->_buildJsObject($polygonOptions) . ').addTo(' . $this->name() . ');
+		';
+
+		$this->map .= $polygon;
+	}
+
+	/**
+	 * Add a GeoJSON layer to the map.
+	 *
+	 * @param array<string, mixed> $data GeoJSON data
+	 * @param array<string, mixed> $options
+	 * @return void
+	 */
+	public function addGeoJson(array $data, array $options = []): void {
+		$geoJsonJs = json_encode($data);
+
+		$optionsJs = '';
+		if ($options) {
+			$optionsJs = ', ' . $this->_buildJsObject($options);
+		}
+
+		$geoJson = '
+		L.geoJSON(' . $geoJsonJs . $optionsJs . ').addTo(' . $this->name() . ');
+		';
+
+		$this->map .= $geoJson;
+	}
+
+	/**
+	 * Add a custom tile layer.
+	 *
+	 * @param string $url Tile URL template
+	 * @param array<string, mixed> $options
+	 * @return void
+	 */
+	public function addTileLayer(string $url, array $options = []): void {
+		$optionsJs = '';
+		if ($options) {
+			$optionsJs = ', ' . $this->_buildJsObject($options);
+		}
+
+		$tileLayer = '
+		L.tileLayer("' . $url . '"' . $optionsJs . ').addTo(' . $this->name() . ');
+		';
+
+		$this->map .= $tileLayer;
+	}
+
+	/**
+	 * Add custom JS.
+	 *
+	 * @param string $js Custom JS
+	 * @return void
+	 */
+	public function addCustom(string $js): void {
+		$this->map .= $js;
+	}
+
+	/**
+	 * This method returns the javascript for the current map container.
+	 * Including script tags.
+	 *
+	 * @return string
+	 */
+	public function script(): string {
+		$script = '<script>
+		' . $this->finalize(true) . '
+</script>';
+
+		return $script;
+	}
+
+	/**
+	 * Finalize the map and write the javascript to the buffer.
+	 * Make sure that your view does also output the buffer at some place!
+	 *
+	 * @param bool $return If the output should be returned instead
+	 * @return string|null Javascript if $return is true
+	 */
+	public function finalize(bool $return = false): ?string {
+		$script = '
+jQuery(document).ready(function() {
+		';
+
+		$script .= $this->map;
+
+		if ($this->_runtimeConfig['autoCenter']) {
+			$script .= $this->_autoCenter();
+		}
+
+		$script .= '
+});';
+		static::$mapCount++;
+		if (!$return) {
+			$this->Html->scriptBlock($script, ['block' => true]);
+
+			return null;
+		}
+
+		return $script;
+	}
+
+	/**
+	 * Json encode string
+	 *
+	 * @param mixed $content
+	 * @return string JSON
+	 */
+	public function escapeString(mixed $content): string {
+		$result = json_encode($content);
+		if ($result === false) {
+			return '';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Auto center map to fit all markers
+	 *
+	 * @return string autoCenterCommands
+	 */
+	protected function _autoCenter(): string {
+		return '
+		if (lMarkers' . static::$mapCount . '.length > 0) {
+			var group = new L.featureGroup(lMarkers' . static::$mapCount . ');
+			' . $this->name() . '.fitBounds(group.getBounds());
+		}
+		';
+	}
+
+	/**
+	 * @return string JSON like js string
+	 */
+	protected function _mapOptions(): string {
+		$options = $this->_runtimeConfig['map'];
+
+		$mapOptions = [];
+		if (isset($options['scrollWheelZoom'])) {
+			$mapOptions['scrollWheelZoom'] = $options['scrollWheelZoom'];
+		}
+		if (isset($options['zoomControl'])) {
+			$mapOptions['zoomControl'] = $options['zoomControl'];
+		}
+		if (isset($options['dragging'])) {
+			$mapOptions['dragging'] = $options['dragging'];
+		}
+
+		return $this->_buildJsObject($mapOptions);
+	}
+
+	/**
+	 * Generate tile layer JavaScript
+	 *
+	 * @return string
+	 */
+	protected function _tileLayerJs(): string {
+		$tileConfig = $this->_runtimeConfig['tileLayer'];
+		$url = $tileConfig['url'];
+		$options = $tileConfig['options'] ?? [];
+
+		return '
+		L.tileLayer("' . $url . '", ' . $this->_buildJsObject($options) . ').addTo(' . $this->name() . ');
+		';
+	}
+
+	/**
+	 * Build a JavaScript object from PHP array
+	 *
+	 * @param array<string, mixed> $options
+	 * @return string
+	 */
+	protected function _buildJsObject(array $options): string {
+		$result = json_encode($options);
+		if ($result === false) {
+			return '{}';
+		}
+
+		return $result;
+	}
+
+}

--- a/tests/TestCase/View/Helper/LeafletHelperTest.php
+++ b/tests/TestCase/View/Helper/LeafletHelperTest.php
@@ -1,0 +1,485 @@
+<?php
+
+namespace Geo\Test\TestCase\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Geo\View\Helper\LeafletHelper;
+
+class LeafletHelperTest extends TestCase {
+
+	/**
+	 * @var \Geo\View\Helper\LeafletHelper
+	 */
+	protected LeafletHelper $Leaflet;
+
+	/**
+	 * @var \Cake\View\View
+	 */
+	protected View $View;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::delete('Leaflet');
+
+		$this->View = new View(null);
+		$this->Leaflet = new LeafletHelper($this->View);
+
+		LeafletHelper::$mapCount = 0;
+		LeafletHelper::$markerCount = 0;
+		LeafletHelper::$popupCount = 0;
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConfigMergeDefaults(): void {
+		$config = [
+			'zoom' => 10,
+			'lat' => 48.1,
+			'lng' => 11.5,
+		];
+		$this->Leaflet = new LeafletHelper($this->View, $config);
+
+		$result = $this->Leaflet->getConfig();
+		$this->assertSame(10, $result['map']['zoom']);
+		$this->assertSame(48.1, $result['map']['lat']);
+		$this->assertSame(11.5, $result['map']['lng']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConfigMergeDeep(): void {
+		$config = [
+			'map' => [
+				'scrollWheelZoom' => false,
+			],
+		];
+		Configure::write('Leaflet.zoom', 8);
+		$this->Leaflet = new LeafletHelper($this->View, $config);
+
+		$result = $this->Leaflet->getConfig();
+		$this->assertSame(8, $result['map']['zoom']);
+		$this->assertFalse($result['map']['scrollWheelZoom']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMap(): void {
+		$options = [
+			'zoom' => 10,
+			'lat' => 48.2082,
+			'lng' => 16.3738,
+		];
+
+		$result = $this->Leaflet->map($options);
+		$result .= $this->Leaflet->script();
+
+		$expected = '<div id="map" class="leaflet-map"';
+		$this->assertTextContains($expected, $result);
+
+		$expected = 'var map0 = L.map("map"';
+		$this->assertTextContains($expected, $result);
+
+		$expected = 'map0.setView([48.2082, 16.3738], 10)';
+		$this->assertTextContains($expected, $result);
+
+		$expected = 'L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"';
+		$this->assertTextContains($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMapCustomId(): void {
+		$options = [
+			'div' => ['id' => 'custom-map'],
+		];
+
+		$result = $this->Leaflet->map($options);
+		$result .= $this->Leaflet->script();
+
+		$expected = '<div id="custom-map"';
+		$this->assertTextContains($expected, $result);
+
+		$expected = 'L.map("custom-map"';
+		$this->assertTextContains($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMapAutoScript(): void {
+		$options = [
+			'autoScript' => true,
+			'block' => false,
+		];
+
+		$result = $this->Leaflet->map($options);
+
+		$expected = 'leaflet.css';
+		$this->assertTextContains($expected, $result);
+
+		$expected = 'leaflet.js';
+		$this->assertTextContains($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddMarker(): void {
+		$this->Leaflet->map();
+		$markerCount = $this->Leaflet->addMarker([
+			'lat' => 48.2082,
+			'lng' => 16.3738,
+			'title' => 'Vienna',
+		]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertSame(0, $markerCount);
+		$this->assertTextContains('L.marker([48.2082, 16.3738]', $result);
+		$this->assertTextContains('"title":"Vienna"', $result);
+		$this->assertTextContains('.addTo(map0)', $result);
+		$this->assertTextContains('lMarkers0.push(x0)', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddMarkerWithPopup(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addMarker([
+			'lat' => 48.2082,
+			'lng' => 16.3738,
+			'content' => '<b>Vienna</b>',
+		]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('x0.bindPopup("<b>Vienna<\\/b>")', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddMarkerOpenPopup(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addMarker([
+			'lat' => 48.2082,
+			'lng' => 16.3738,
+			'content' => 'Test content',
+			'open' => true,
+		]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('x0.openPopup()', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddPopup(): void {
+		$this->Leaflet->map();
+		$popupCount = $this->Leaflet->addPopup([
+			'lat' => 48.2082,
+			'lng' => 16.3738,
+			'content' => 'Hello World',
+		]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertSame(0, $popupCount);
+		$this->assertTextContains('L.popup(', $result);
+		$this->assertTextContains('.setLatLng([48.2082, 16.3738])', $result);
+		$this->assertTextContains('.setContent("Hello World")', $result);
+		$this->assertTextContains('.openOn(map0)', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddPolyline(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addPolyline(
+			['lat' => 48.2082, 'lng' => 16.3738],
+			['lat' => 47.0707, 'lng' => 15.4395],
+		);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.polyline([[48.2082, 16.3738], [47.0707, 15.4395]]', $result);
+		$this->assertTextContains('"color":"#3388ff"', $result);
+		$this->assertTextContains('"weight":3', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddPolylineFromPoints(): void {
+		$points = [
+			['lat' => 48.2082, 'lng' => 16.3738],
+			['lat' => 47.0707, 'lng' => 15.4395],
+			['lat' => 46.0569, 'lng' => 14.5058],
+		];
+		$this->Leaflet->map();
+		$this->Leaflet->addPolylineFromPoints($points, ['color' => '#ff0000']);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.polyline([[48.2082, 16.3738], [47.0707, 15.4395], [46.0569, 14.5058]]', $result);
+		$this->assertTextContains('"color":"#ff0000"', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddCircle(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addCircle([
+			'lat' => 48.2082,
+			'lng' => 16.3738,
+			'radius' => 1000,
+			'color' => '#ff0000',
+		]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.circle([48.2082, 16.3738]', $result);
+		$this->assertTextContains('"radius":1000', $result);
+		$this->assertTextContains('"color":"#ff0000"', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddPolygon(): void {
+		$points = [
+			['lat' => 48.2, 'lng' => 16.3],
+			['lat' => 48.3, 'lng' => 16.4],
+			['lat' => 48.1, 'lng' => 16.5],
+		];
+		$this->Leaflet->map();
+		$this->Leaflet->addPolygon($points);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.polygon([[48.2, 16.3], [48.3, 16.4], [48.1, 16.5]]', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddGeoJson(): void {
+		$geoJson = [
+			'type' => 'Feature',
+			'geometry' => [
+				'type' => 'Point',
+				'coordinates' => [16.3738, 48.2082],
+			],
+		];
+		$this->Leaflet->map();
+		$this->Leaflet->addGeoJson($geoJson);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.geoJSON(', $result);
+		$this->assertTextContains('"type":"Feature"', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUseTilePreset(): void {
+		$this->Leaflet->useTilePreset(LeafletHelper::TILES_CARTO_DARK);
+		$this->Leaflet->map();
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('basemaps.cartocdn.com/dark_all', $result);
+		$this->assertTextContains('CARTO', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUseTilePresetInvalid(): void {
+		$this->Leaflet->useTilePreset('invalid_preset');
+		$this->Leaflet->map();
+
+		$result = $this->Leaflet->script();
+
+		// Should fall back to default OSM tiles
+		$this->assertTextContains('tile.openstreetmap.org', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddTileLayer(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addTileLayer(
+			'https://custom.tiles/{z}/{x}/{y}.png',
+			['attribution' => 'Custom'],
+		);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.tileLayer("https://custom.tiles/{z}/{x}/{y}.png"', $result);
+		$this->assertTextContains('"attribution":"Custom"', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReset(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addMarker(['lat' => 48.2, 'lng' => 16.3]);
+		$this->Leaflet->addMarker(['lat' => 47.0, 'lng' => 15.4]);
+		$this->Leaflet->finalize();
+
+		// Reset for second map
+		$this->Leaflet->reset();
+
+		$this->assertSame(0, LeafletHelper::$markerCount);
+		$this->assertEmpty($this->Leaflet->markers);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMultipleMaps(): void {
+		// First map
+		$result1 = $this->Leaflet->map(['div' => ['id' => 'map1']]);
+		$this->Leaflet->addMarker(['lat' => 48.2, 'lng' => 16.3]);
+		$result1 .= $this->Leaflet->script();
+
+		// Second map
+		$result2 = $this->Leaflet->map(['div' => ['id' => 'map2']]);
+		$this->Leaflet->addMarker(['lat' => 47.0, 'lng' => 15.4]);
+		$result2 .= $this->Leaflet->script();
+
+		$this->assertTextContains('id="map1"', $result1);
+		$this->assertTextContains('var map0 = L.map("map1"', $result1);
+		$this->assertTextContains('lMarkers0.push(x0)', $result1);
+
+		$this->assertTextContains('id="map2"', $result2);
+		$this->assertTextContains('var map1 = L.map("map2"', $result2);
+		$this->assertTextContains('lMarkers1.push(x0)', $result2);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFinalize(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->finalize();
+
+		$scripts = $this->View->fetch('script');
+		$this->assertTextContains('jQuery(document).ready', $scripts);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAutoCenter(): void {
+		$options = [
+			'autoCenter' => true,
+		];
+		$this->Leaflet->map($options);
+		$this->Leaflet->addMarker(['lat' => 48.2, 'lng' => 16.3]);
+		$this->Leaflet->addMarker(['lat' => 47.0, 'lng' => 15.4]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.featureGroup(lMarkers0)', $result);
+		$this->assertTextContains('fitBounds(group.getBounds())', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddCustom(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addCustom('console.log("custom js");');
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('console.log("custom js")', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testName(): void {
+		$this->Leaflet->map();
+
+		$this->assertSame('map0', $this->Leaflet->name());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testId(): void {
+		$this->Leaflet->map(['div' => ['id' => 'my-map']]);
+
+		$this->assertSame('my-map', $this->Leaflet->id());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMapOptionsScrollWheelZoom(): void {
+		$options = [
+			'map' => [
+				'scrollWheelZoom' => false,
+			],
+		];
+		$this->Leaflet->map($options);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('"scrollWheelZoom":false', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMarkerDraggable(): void {
+		$this->Leaflet->map();
+		$this->Leaflet->addMarker([
+			'lat' => 48.2,
+			'lng' => 16.3,
+			'draggable' => true,
+		]);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('"draggable":true', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDuplicateMapIdHandling(): void {
+		// First map with same id
+		$result1 = $this->Leaflet->map(['div' => ['id' => 'map']]);
+		$this->Leaflet->finalize();
+
+		// Second map with same id - should be renamed
+		$result2 = $this->Leaflet->map(['div' => ['id' => 'map']]);
+		$this->Leaflet->finalize();
+
+		$this->assertTextContains('id="map"', $result1);
+		$this->assertTextContains('id="map-1"', $result2);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add LeafletHelper as an open-source alternative to GoogleMapHelper for rendering interactive maps using Leaflet.js
- No external PHP dependencies - direct JavaScript generation (same pattern as GoogleMapHelper)
- Tile provider presets (OpenStreetMap, CartoDB Light/Dark)
- Support for markers, popups, polylines, circles, polygons, and GeoJSON layers
- Auto-center functionality with fitBounds
- Multiple maps per page support
- Full test coverage (27 tests, all passing)
- Documentation with usage examples

## Test plan

- [x] All 27 LeafletHelper tests pass
- [x] Full test suite passes (90 tests)
- [x] PHPStan passes
- [x] PHPCS passes