### PR TITLE
Add provider-based engine architecture to Geocoder

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Example configuration for CakePHP Geo plugin.
+ *
+ * Copy the relevant parts to your config/app_local.php file.
+ */
+
+use Geo\Geocoder\Geocoder;
+
+return [
+	/**
+	 * Geocoder configuration.
+	 *
+	 * Available providers:
+	 * - Geocoder::PROVIDER_GOOGLE (default) - requires API key
+	 * - Geocoder::PROVIDER_NOMINATIM - free, OpenStreetMap-based
+	 * - Geocoder::PROVIDER_GEOAPIFY - requires API key (has free tier)
+	 * - Geocoder::PROVIDER_NULL - for testing (returns empty results)
+	 */
+	'Geocoder' => [
+		// Provider selection (use constants or callable)
+		'provider' => Geocoder::PROVIDER_GOOGLE,
+
+		// Global settings (used as fallbacks for provider-specific config)
+		'apiKey' => env('GEOCODER_API_KEY', ''),
+		'locale' => null, // e.g., 'en', 'de', or true to auto-detect from I18n
+		'region' => null, // e.g., 'us', 'de', or true to auto-detect from I18n
+
+		// Result handling
+		'allowInconclusive' => true, // Allow multiple results
+		'minAccuracy' => Geocoder::TYPE_COUNTRY, // Minimum accuracy level, or null to disable
+		'expect' => [], // Expected address types, e.g., [Geocoder::TYPE_POSTAL, Geocoder::TYPE_LOC]
+
+		// Google Maps provider settings
+		'google' => [
+			'apiKey' => env('GOOGLE_MAPS_API_KEY', ''),
+			'locale' => 'en',
+			'region' => null, // e.g., 'us' for US biasing
+		],
+
+		// Nominatim (OpenStreetMap) provider settings
+		'nominatim' => [
+			'userAgent' => 'MyApp/1.0', // Required by OSM usage policy
+			'rootUrl' => 'https://nominatim.openstreetmap.org', // Or your own Nominatim instance
+			'locale' => 'en',
+		],
+
+		// Geoapify provider settings
+		'geoapify' => [
+			'apiKey' => env('GEOAPIFY_API_KEY', ''),
+			'locale' => 'en',
+		],
+	],
+];

--- a/docs/Behavior/Geocoder.md
+++ b/docs/Behavior/Geocoder.md
@@ -35,12 +35,12 @@ By default, it will use the GoogleMaps provider. You can switch providers using 
 
 ### Available Providers
 
-| Provider | Constant | API Key | Notes |
-|----------|----------|---------|-------|
-| Google Maps | `Geocoder::PROVIDER_GOOGLE` | Required | Default, most reliable |
-| Nominatim | `Geocoder::PROVIDER_NOMINATIM` | No | Free, OpenStreetMap-based |
-| Geoapify | `Geocoder::PROVIDER_GEOAPIFY` | Required (free tier) | Good alternative |
-| Null | `Geocoder::PROVIDER_NULL` | No | For testing |
+| Provider | API Key | Notes |
+|----------|---------|-------|
+| Google Maps | Required | Default, most reliable |
+| Nominatim | No | Free, OpenStreetMap-based |
+| Geoapify | Required (free tier) | Good alternative |
+| Null | No | For testing |
 
 ### Using Provider Constants
 
@@ -61,6 +61,8 @@ use Geo\Geocoder\Geocoder;
 Or using Geoapify:
 
 ```php
+use Geo\Geocoder\Geocoder;
+
 'Geocoder' => [
     'provider' => Geocoder::PROVIDER_GEOAPIFY,
     'geoapify' => [

--- a/docs/Behavior/Geocoder.md
+++ b/docs/Behavior/Geocoder.md
@@ -29,23 +29,50 @@ Possible config options are:
 
 Note that it is usually better to set global configs in your `app.php` using the `Geocoder` key.
 
-## Configure your own Geocoder
-By default, it will use the GoogleMaps provider.
+## Configure your Geocoder
 
-Please see [geocoder-php/Geocoder](https://github.com/geocoder-php/Geocoder) library on what other providers you can use out of the box.
-You can choose from
-- 12+ address-based Geocoder providers
-- 10+ IP-based Geocoder providers
+By default, it will use the GoogleMaps provider. You can switch providers using the built-in provider constants.
 
-You could easily switch to an IP based provider like this:
+### Available Providers
+
+| Provider | Constant | API Key | Notes |
+|----------|----------|---------|-------|
+| Google Maps | `Geocoder::PROVIDER_GOOGLE` | Required | Default, most reliable |
+| Nominatim | `Geocoder::PROVIDER_NOMINATIM` | No | Free, OpenStreetMap-based |
+| Geoapify | `Geocoder::PROVIDER_GEOAPIFY` | Required (free tier) | Good alternative |
+| Null | `Geocoder::PROVIDER_NULL` | No | For testing |
+
+### Using Provider Constants
+
+Switch to a different provider easily:
+
 ```php
+use Geo\Geocoder\Geocoder;
+
 // in your app.php config
 'Geocoder' => [
-    'provider' => '\Geocoder\Provider\FreeGeoIp',
+    'provider' => Geocoder::PROVIDER_NOMINATIM,
+    'nominatim' => [
+        'userAgent' => 'MyApp/1.0',  // Required by OSM usage policy
+    ],
 ],
 ```
 
-Let's say you want to switch to OpenStreetMap and also use a different HTTP adapter:
+Or using Geoapify:
+
+```php
+'Geocoder' => [
+    'provider' => Geocoder::PROVIDER_GEOAPIFY,
+    'geoapify' => [
+        'apiKey' => env('GEOAPIFY_API_KEY'),
+    ],
+],
+```
+
+### Using a Callable (Advanced)
+
+For advanced use cases or custom providers from the geocoder-php library:
+
 ```php
 // in your app.php config
 'Geocoder' => [
@@ -57,7 +84,12 @@ Let's say you want to switch to OpenStreetMap and also use a different HTTP adap
 ],
 ```
 
-Note: Don't forget that most providers need an apiKey to work.
+Please see [geocoder-php/Geocoder](https://github.com/geocoder-php/Geocoder) library on what other providers you can use.
+You can choose from:
+- 12+ address-based Geocoder providers
+- 10+ IP-based Geocoder providers
+
+Note: Most providers need an apiKey to work.
 
 ## Saving geocodable data
 

--- a/docs/Geocoder/Geocoder.md
+++ b/docs/Geocoder/Geocoder.md
@@ -33,12 +33,12 @@ $result = $Geocoder->reverse($lat, $lng);
 
 The Geocoder supports multiple geocoding providers out of the box. Use provider constants to specify which provider to use:
 
-| Provider | Constant | API Key | Notes |
-|----------|----------|---------|-------|
-| Google Maps | `Geocoder::PROVIDER_GOOGLE` | Required | Default, most reliable |
-| Nominatim | `Geocoder::PROVIDER_NOMINATIM` | No | Free, OpenStreetMap-based |
-| Geoapify | `Geocoder::PROVIDER_GEOAPIFY` | Required (free tier) | Good alternative |
-| Null | `Geocoder::PROVIDER_NULL` | No | For testing |
+| Provider | API Key | Notes |
+|----------|---------|-------|
+| Google Maps | Required | Default, most reliable |
+| Nominatim | No | Free, OpenStreetMap-based |
+| Geoapify | Required (free tier) | Good alternative |
+| Null | No | For testing |
 
 ### Using String Provider Names
 
@@ -63,8 +63,10 @@ Configure providers with their specific settings:
 
 ```php
 // config/app_local.php
+use Geo\Geocoder\Geocoder;
+
 'Geocoder' => [
-    'provider' => 'nominatim',
+    'provider' => Geocoder::PROVIDER_NOMINATIM,
     'allowInconclusive' => true,
     'minAccuracy' => Geocoder::TYPE_COUNTRY,
     'google' => [

--- a/docs/Geocoder/Geocoder.md
+++ b/docs/Geocoder/Geocoder.md
@@ -28,3 +28,124 @@ Since it is using GoogleMaps geocoding service underneath by default, make sure 
 ```php
 $result = $Geocoder->reverse($lat, $lng);
 ```
+
+## Providers
+
+The Geocoder supports multiple geocoding providers out of the box. Use provider constants to specify which provider to use:
+
+| Provider | Constant | API Key | Notes |
+|----------|----------|---------|-------|
+| Google Maps | `Geocoder::PROVIDER_GOOGLE` | Required | Default, most reliable |
+| Nominatim | `Geocoder::PROVIDER_NOMINATIM` | No | Free, OpenStreetMap-based |
+| Geoapify | `Geocoder::PROVIDER_GEOAPIFY` | Required (free tier) | Good alternative |
+| Null | `Geocoder::PROVIDER_NULL` | No | For testing |
+
+### Using String Provider Names
+
+```php
+use Geo\Geocoder\Geocoder;
+
+// Use Nominatim (OpenStreetMap)
+$geocoder = new Geocoder([
+    'provider' => Geocoder::PROVIDER_NOMINATIM,
+]);
+
+// Use Geoapify
+$geocoder = new Geocoder([
+    'provider' => Geocoder::PROVIDER_GEOAPIFY,
+    'apiKey' => 'your-geoapify-key',
+]);
+```
+
+### Provider-Specific Configuration
+
+Configure providers with their specific settings:
+
+```php
+// config/app_local.php
+'Geocoder' => [
+    'provider' => 'nominatim',
+    'allowInconclusive' => true,
+    'minAccuracy' => Geocoder::TYPE_COUNTRY,
+    'google' => [
+        'apiKey' => env('GOOGLE_MAPS_API_KEY'),
+        'region' => 'us',
+    ],
+    'nominatim' => [
+        'userAgent' => 'MyApp/1.0',  // Required by OSM policy
+    ],
+    'geoapify' => [
+        'apiKey' => env('GEOAPIFY_API_KEY'),
+    ],
+],
+```
+
+### Using a Callable (Legacy/Advanced)
+
+For advanced use cases or custom providers from geocoder-php:
+
+```php
+'Geocoder' => [
+    'provider' => function () {
+        return \Geocoder\Provider\Nominatim\Nominatim::withOpenStreetMapServer(
+            new \Http\Adapter\Cake\Client(),
+            'User-Agent'
+        );
+    },
+],
+```
+
+## Creating Custom Providers
+
+You can create custom providers by implementing `GeocodingProviderInterface`:
+
+```php
+namespace App\Geocoder\Provider;
+
+use Geo\Geocoder\Provider\AbstractGeocodingProvider;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Provider;
+
+class MyCustomProvider extends AbstractGeocodingProvider {
+
+    protected array $_defaultConfig = [
+        'apiKey' => null,
+        'locale' => 'en',
+        'baseUrl' => 'https://api.myservice.com/geocode',
+    ];
+
+    public function getName(): string {
+        return 'mycustom';
+    }
+
+    public function requiresApiKey(): bool {
+        return true;
+    }
+
+    protected function buildProvider(): Provider {
+        // Return a geocoder-php provider instance
+        // or throw UnsupportedOperation and override geocode/reverse methods
+    }
+}
+```
+
+Register your custom provider:
+
+```php
+use Geo\Geocoder\Geocoder;
+use App\Geocoder\Provider\MyCustomProvider;
+
+// Register the provider
+Geocoder::registerProvider('mycustom', MyCustomProvider::class);
+
+// Use it
+$geocoder = new Geocoder(['provider' => 'mycustom']);
+```
+
+Or use it directly via callable:
+
+```php
+'Geocoder' => [
+    'provider' => fn () => new MyCustomProvider(['apiKey' => '...']),
+],
+```

--- a/src/Geocoder/Provider/AbstractGeocodingProvider.php
+++ b/src/Geocoder/Provider/AbstractGeocodingProvider.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Geocoder\Provider;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\Http\Client;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Provider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+use Geocoder\StatefulGeocoder;
+
+/**
+ * Abstract base class for geocoding providers.
+ *
+ * Provides common functionality for geocoding operations using
+ * the willdurand/geocoder library providers.
+ */
+abstract class AbstractGeocodingProvider implements GeocodingProviderInterface {
+
+	use InstanceConfigTrait;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'apiKey' => null,
+		'locale' => 'en',
+		'region' => null,
+	];
+
+	/**
+	 * @var \Cake\Http\Client|null
+	 */
+	protected ?Client $httpClient = null;
+
+	/**
+	 * @var \Geocoder\Provider\Provider|null
+	 */
+	protected ?Provider $provider = null;
+
+	/**
+	 * @var \Geocoder\StatefulGeocoder|null
+	 */
+	protected ?StatefulGeocoder $geocoder = null;
+
+	/**
+	 * @param array<string, mixed> $config
+	 */
+	public function __construct(array $config = []) {
+		$this->setConfig($config);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function geocode(string $address): AddressCollection {
+		$geocoder = $this->getGeocoder();
+
+		/** @var \Geocoder\Model\AddressCollection $result */
+		$result = $geocoder->geocodeQuery(GeocodeQuery::create($address));
+
+		return $result;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function reverse(float $lat, float $lng): AddressCollection {
+		$geocoder = $this->getGeocoder();
+
+		/** @var \Geocoder\Model\AddressCollection $result */
+		$result = $geocoder->reverseQuery(ReverseQuery::fromCoordinates($lat, $lng));
+
+		return $result;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function requiresApiKey(): bool {
+		return true;
+	}
+
+	/**
+	 * Get the HTTP client instance.
+	 *
+	 * @return \Cake\Http\Client
+	 */
+	protected function getHttpClient(): Client {
+		if ($this->httpClient === null) {
+			$this->httpClient = new Client();
+		}
+
+		return $this->httpClient;
+	}
+
+	/**
+	 * Get the stateful geocoder instance.
+	 *
+	 * @return \Geocoder\StatefulGeocoder
+	 */
+	protected function getGeocoder(): StatefulGeocoder {
+		if ($this->geocoder === null) {
+			$provider = $this->buildProvider();
+			$locale = $this->getConfig('locale') ?: 'en';
+			$this->geocoder = new StatefulGeocoder($provider, $locale);
+		}
+
+		return $this->geocoder;
+	}
+
+	/**
+	 * Build the underlying geocoder-php provider.
+	 *
+	 * @return \Geocoder\Provider\Provider
+	 */
+	abstract protected function buildProvider(): Provider;
+
+}

--- a/src/Geocoder/Provider/GeoapifyProvider.php
+++ b/src/Geocoder/Provider/GeoapifyProvider.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Geocoder\Provider;
+
+use Geocoder\Exception\InvalidServerResponse;
+use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Model\Address;
+use Geocoder\Model\AddressBuilder;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Provider;
+
+/**
+ * Geoapify geocoding provider.
+ *
+ * Uses the Geoapify Geocoding API which has a generous free tier.
+ *
+ * @link https://www.geoapify.com/geocoding-api
+ * @link https://apidocs.geoapify.com/docs/geocoding/
+ */
+class GeoapifyProvider extends AbstractGeocodingProvider {
+
+	/**
+	 * @var string
+	 */
+	protected const GEOCODE_URL = 'https://api.geoapify.com/v1/geocode/search';
+
+	/**
+	 * @var string
+	 */
+	protected const REVERSE_URL = 'https://api.geoapify.com/v1/geocode/reverse';
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'apiKey' => null,
+		'locale' => 'en',
+		'region' => null,
+	];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName(): string {
+		return 'geoapify';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function requiresApiKey(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function geocode(string $address): AddressCollection {
+		$apiKey = $this->getConfig('apiKey');
+		if (!$apiKey) {
+			throw new UnsupportedOperation('Geoapify requires an API key.');
+		}
+
+		$url = static::GEOCODE_URL . '?' . http_build_query([
+			'text' => $address,
+			'apiKey' => $apiKey,
+			'lang' => $this->getConfig('locale') ?: 'en',
+		]);
+
+		return $this->executeQuery($url);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function reverse(float $lat, float $lng): AddressCollection {
+		$apiKey = $this->getConfig('apiKey');
+		if (!$apiKey) {
+			throw new UnsupportedOperation('Geoapify requires an API key.');
+		}
+
+		$url = static::REVERSE_URL . '?' . http_build_query([
+			'lat' => $lat,
+			'lon' => $lng,
+			'apiKey' => $apiKey,
+			'lang' => $this->getConfig('locale') ?: 'en',
+		]);
+
+		return $this->executeQuery($url);
+	}
+
+	/**
+	 * Execute a query against the Geoapify API.
+	 *
+     * @param string $url The API URL
+     * @throws \Geocoder\Exception\InvalidServerResponse
+     * @return \Geocoder\Model\AddressCollection
+	 */
+	protected function executeQuery(string $url): AddressCollection {
+		$response = $this->getHttpClient()->get($url);
+
+		if (!$response->isOk()) {
+			throw new InvalidServerResponse(
+				sprintf('Geoapify API returned status %d', $response->getStatusCode()),
+			);
+		}
+
+		$data = $response->getJson();
+		if (!is_array($data) || !isset($data['features'])) {
+			throw new InvalidServerResponse('Invalid response from Geoapify API');
+		}
+
+		$addresses = [];
+		foreach ($data['features'] as $feature) {
+			$address = $this->parseFeature($feature);
+			if ($address !== null) {
+				$addresses[] = $address;
+			}
+		}
+
+		return new AddressCollection($addresses);
+	}
+
+	/**
+	 * Parse a GeoJSON feature into an Address object.
+	 *
+	 * @param array<string, mixed> $feature The GeoJSON feature
+	 * @return \Geocoder\Model\Address|null
+	 */
+	protected function parseFeature(array $feature): ?Address {
+		if (!isset($feature['properties']) || !isset($feature['geometry'])) {
+			return null;
+		}
+
+		$props = $feature['properties'];
+		$coords = $feature['geometry']['coordinates'] ?? null;
+
+		$builder = new AddressBuilder($this->getName());
+
+		if ($coords && count($coords) >= 2) {
+			$builder->setCoordinates($coords[1], $coords[0]);
+		}
+
+		if (!empty($props['street'])) {
+			$builder->setStreetName($props['street']);
+		}
+
+		if (!empty($props['housenumber'])) {
+			$builder->setStreetNumber($props['housenumber']);
+		}
+
+		if (!empty($props['postcode'])) {
+			$builder->setPostalCode($props['postcode']);
+		}
+
+		if (!empty($props['city'])) {
+			$builder->setLocality($props['city']);
+		}
+
+		if (!empty($props['district'])) {
+			$builder->setSubLocality($props['district']);
+		}
+
+		if (!empty($props['state'])) {
+			$builder->addAdminLevel(1, $props['state'], $props['state_code'] ?? null);
+		}
+
+		if (!empty($props['county'])) {
+			$builder->addAdminLevel(2, $props['county']);
+		}
+
+		if (!empty($props['country'])) {
+			$builder->setCountry($props['country']);
+		}
+
+		if (!empty($props['country_code'])) {
+			$builder->setCountryCode(strtoupper($props['country_code']));
+		}
+
+		return $builder->build();
+	}
+
+	/**
+	 * Not used for this custom implementation.
+	 *
+	 * @return \Geocoder\Provider\Provider
+	 */
+	protected function buildProvider(): Provider {
+		throw new UnsupportedOperation('GeoapifyProvider uses custom HTTP implementation.');
+	}
+
+}

--- a/src/Geocoder/Provider/GeocodingProviderInterface.php
+++ b/src/Geocoder/Provider/GeocodingProviderInterface.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Geocoder\Provider;
+
+use Geocoder\Model\AddressCollection;
+
+/**
+ * Interface for geocoding providers.
+ *
+ * Each provider implements geocoding and reverse geocoding using their specific API.
+ */
+interface GeocodingProviderInterface {
+
+	/**
+	 * Get the provider name.
+	 *
+	 * @return string
+	 */
+	public function getName(): string;
+
+	/**
+	 * Geocode an address string to coordinates.
+	 *
+	 * @param string $address The address to geocode
+	 * @return \Geocoder\Model\AddressCollection
+	 */
+	public function geocode(string $address): AddressCollection;
+
+	/**
+	 * Reverse geocode coordinates to an address.
+	 *
+	 * @param float $lat Latitude
+	 * @param float $lng Longitude
+	 * @return \Geocoder\Model\AddressCollection
+	 */
+	public function reverse(float $lat, float $lng): AddressCollection;
+
+	/**
+	 * Check if this provider requires an API key.
+	 *
+	 * @return bool
+	 */
+	public function requiresApiKey(): bool;
+
+}

--- a/src/Geocoder/Provider/GoogleProvider.php
+++ b/src/Geocoder/Provider/GoogleProvider.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Geocoder\Provider;
+
+use Geocoder\Provider\GoogleMaps\GoogleMaps;
+use Geocoder\Provider\Provider;
+
+/**
+ * Google Maps geocoding provider.
+ *
+ * @link https://developers.google.com/maps/documentation/geocoding/
+ */
+class GoogleProvider extends AbstractGeocodingProvider {
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'apiKey' => null,
+		'locale' => 'en',
+		'region' => null,
+	];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName(): string {
+		return 'google';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function requiresApiKey(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function buildProvider(): Provider {
+		return new GoogleMaps(
+			$this->getHttpClient(),
+			$this->getConfig('region'),
+			$this->getConfig('apiKey'),
+		);
+	}
+
+}

--- a/src/Geocoder/Provider/NominatimProvider.php
+++ b/src/Geocoder/Provider/NominatimProvider.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Geocoder\Provider;
+
+use Geocoder\Provider\Nominatim\Nominatim;
+use Geocoder\Provider\Provider;
+
+/**
+ * Nominatim (OpenStreetMap) geocoding provider.
+ *
+ * This provider uses the free OpenStreetMap Nominatim service.
+ * No API key required, but a user agent string is mandatory
+ * per OpenStreetMap's usage policy.
+ *
+ * @link https://nominatim.org/release-docs/develop/api/Overview/
+ * @link https://operations.osmfoundation.org/policies/nominatim/
+ */
+class NominatimProvider extends AbstractGeocodingProvider {
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'apiKey' => null,
+		'locale' => 'en',
+		'region' => null,
+		'userAgent' => 'CakePHP-Geo-Plugin',
+		'rootUrl' => 'https://nominatim.openstreetmap.org',
+	];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName(): string {
+		return 'nominatim';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function requiresApiKey(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function buildProvider(): Provider {
+		$rootUrl = $this->getConfig('rootUrl');
+		$userAgent = $this->getConfig('userAgent');
+
+		if ($rootUrl === 'https://nominatim.openstreetmap.org') {
+			return Nominatim::withOpenStreetMapServer(
+				$this->getHttpClient(),
+				$userAgent,
+			);
+		}
+
+		return new Nominatim(
+			$this->getHttpClient(),
+			$rootUrl,
+			$userAgent,
+		);
+	}
+
+}

--- a/src/Geocoder/Provider/NullProvider.php
+++ b/src/Geocoder/Provider/NullProvider.php
@@ -11,8 +11,11 @@ use Geocoder\Query\ReverseQuery;
 
 /**
  * Null provider for testing that returns empty results without making API calls.
+ *
+ * Implements both the willdurand/geocoder Provider interface and the
+ * plugin's GeocodingProviderInterface for maximum compatibility.
  */
-class NullProvider implements Provider {
+class NullProvider implements Provider, GeocodingProviderInterface {
 
 	/**
 	 * @param \Geocoder\Query\GeocodeQuery $query
@@ -31,10 +34,31 @@ class NullProvider implements Provider {
 	}
 
 	/**
-	 * @return string
+	 * @inheritDoc
 	 */
 	public function getName(): string {
 		return 'null';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function geocode(string $address): AddressCollection {
+		return new AddressCollection([]);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function reverse(float $lat, float $lng): AddressCollection {
+		return new AddressCollection([]);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function requiresApiKey(): bool {
+		return false;
 	}
 
 }

--- a/tests/TestCase/Geocoder/GeocoderProviderTest.php
+++ b/tests/TestCase/Geocoder/GeocoderProviderTest.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Test\TestCase\Geocoder;
+
+use Cake\TestSuite\TestCase;
+use Geo\Geocoder\Geocoder;
+use Geo\Geocoder\Provider\GeoapifyProvider;
+use Geo\Geocoder\Provider\GoogleProvider;
+use Geo\Geocoder\Provider\NominatimProvider;
+use Geo\Geocoder\Provider\NullProvider;
+
+class GeocoderProviderTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testProviderConstants(): void {
+		$this->assertSame('google', Geocoder::PROVIDER_GOOGLE);
+		$this->assertSame('nominatim', Geocoder::PROVIDER_NOMINATIM);
+		$this->assertSame('geoapify', Geocoder::PROVIDER_GEOAPIFY);
+		$this->assertSame('null', Geocoder::PROVIDER_NULL);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetProviders(): void {
+		$providers = Geocoder::getProviders();
+
+		$this->assertArrayHasKey('google', $providers);
+		$this->assertArrayHasKey('nominatim', $providers);
+		$this->assertArrayHasKey('geoapify', $providers);
+		$this->assertArrayHasKey('null', $providers);
+
+		$this->assertSame(GoogleProvider::class, $providers['google']);
+		$this->assertSame(NominatimProvider::class, $providers['nominatim']);
+		$this->assertSame(GeoapifyProvider::class, $providers['geoapify']);
+		$this->assertSame(NullProvider::class, $providers['null']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterCustomProvider(): void {
+		$customProviderClass = NullProvider::class;
+
+		Geocoder::registerProvider('custom', $customProviderClass);
+		$providers = Geocoder::getProviders();
+
+		$this->assertArrayHasKey('custom', $providers);
+		$this->assertSame($customProviderClass, $providers['custom']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNullProviderReturnsEmptyResults(): void {
+		$geocoder = new Geocoder([
+			'provider' => Geocoder::PROVIDER_NULL,
+			'minAccuracy' => null,
+		]);
+
+		$result = $geocoder->geocode('Berlin, Germany');
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNullProviderReverseReturnsEmptyResults(): void {
+		$geocoder = new Geocoder([
+			'provider' => Geocoder::PROVIDER_NULL,
+			'minAccuracy' => null,
+		]);
+
+		$result = $geocoder->reverse(52.52, 13.405);
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProviderInstanceConfig(): void {
+		$provider = new NullProvider();
+
+		$geocoder = new Geocoder([
+			'provider' => $provider,
+			'minAccuracy' => null,
+		]);
+
+		$result = $geocoder->geocode('Berlin, Germany');
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCallableProviderBackwardCompatibility(): void {
+		$geocoder = new Geocoder([
+			'provider' => fn () => new NullProvider(),
+			'minAccuracy' => null,
+		]);
+
+		$result = $geocoder->geocode('Berlin, Germany');
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProviderSpecificConfigMerge(): void {
+		$geocoder = new Geocoder([
+			'provider' => Geocoder::PROVIDER_NOMINATIM,
+			'locale' => 'de',
+			'nominatim' => [
+				'userAgent' => 'CustomApp/2.0',
+			],
+		]);
+
+		$this->assertSame('de', $geocoder->getConfig('locale'));
+		$this->assertSame('CustomApp/2.0', $geocoder->getConfig('nominatim.userAgent'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGlobalApiKeyFallback(): void {
+		$geocoder = new Geocoder([
+			'provider' => Geocoder::PROVIDER_GOOGLE,
+			'apiKey' => 'global-key',
+		]);
+
+		$this->assertSame('global-key', $geocoder->getConfig('apiKey'));
+	}
+
+}

--- a/tests/TestCase/Geocoder/Provider/GeoapifyProviderTest.php
+++ b/tests/TestCase/Geocoder/Provider/GeoapifyProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Test\TestCase\Geocoder\Provider;
+
+use Cake\TestSuite\TestCase;
+use Geo\Geocoder\Provider\GeoapifyProvider;
+use Geocoder\Exception\UnsupportedOperation;
+
+class GeoapifyProviderTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testGetName(): void {
+		$provider = new GeoapifyProvider();
+
+		$this->assertSame('geoapify', $provider->getName());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRequiresApiKey(): void {
+		$provider = new GeoapifyProvider();
+
+		$this->assertTrue($provider->requiresApiKey());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConfig(): void {
+		$provider = new GeoapifyProvider([
+			'apiKey' => 'test-key',
+			'locale' => 'de',
+		]);
+
+		$this->assertSame('test-key', $provider->getConfig('apiKey'));
+		$this->assertSame('de', $provider->getConfig('locale'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDefaultConfig(): void {
+		$provider = new GeoapifyProvider();
+
+		$this->assertNull($provider->getConfig('apiKey'));
+		$this->assertSame('en', $provider->getConfig('locale'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGeocodeWithoutApiKeyThrows(): void {
+		$provider = new GeoapifyProvider();
+
+		$this->expectException(UnsupportedOperation::class);
+		$this->expectExceptionMessage('Geoapify requires an API key');
+
+		$provider->geocode('Berlin, Germany');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReverseWithoutApiKeyThrows(): void {
+		$provider = new GeoapifyProvider();
+
+		$this->expectException(UnsupportedOperation::class);
+		$this->expectExceptionMessage('Geoapify requires an API key');
+
+		$provider->reverse(52.52, 13.405);
+	}
+
+}

--- a/tests/TestCase/Geocoder/Provider/GoogleProviderTest.php
+++ b/tests/TestCase/Geocoder/Provider/GoogleProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Test\TestCase\Geocoder\Provider;
+
+use Cake\TestSuite\TestCase;
+use Geo\Geocoder\Provider\GoogleProvider;
+
+class GoogleProviderTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testGetName(): void {
+		$provider = new GoogleProvider();
+
+		$this->assertSame('google', $provider->getName());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRequiresApiKey(): void {
+		$provider = new GoogleProvider();
+
+		$this->assertTrue($provider->requiresApiKey());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConfig(): void {
+		$provider = new GoogleProvider([
+			'apiKey' => 'test-key',
+			'locale' => 'de',
+			'region' => 'de',
+		]);
+
+		$this->assertSame('test-key', $provider->getConfig('apiKey'));
+		$this->assertSame('de', $provider->getConfig('locale'));
+		$this->assertSame('de', $provider->getConfig('region'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDefaultConfig(): void {
+		$provider = new GoogleProvider();
+
+		$this->assertNull($provider->getConfig('apiKey'));
+		$this->assertSame('en', $provider->getConfig('locale'));
+		$this->assertNull($provider->getConfig('region'));
+	}
+
+}

--- a/tests/TestCase/Geocoder/Provider/NominatimProviderTest.php
+++ b/tests/TestCase/Geocoder/Provider/NominatimProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Test\TestCase\Geocoder\Provider;
+
+use Cake\TestSuite\TestCase;
+use Geo\Geocoder\Provider\NominatimProvider;
+
+class NominatimProviderTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testGetName(): void {
+		$provider = new NominatimProvider();
+
+		$this->assertSame('nominatim', $provider->getName());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRequiresApiKey(): void {
+		$provider = new NominatimProvider();
+
+		$this->assertFalse($provider->requiresApiKey());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConfig(): void {
+		$provider = new NominatimProvider([
+			'locale' => 'de',
+			'userAgent' => 'MyApp/1.0',
+		]);
+
+		$this->assertSame('de', $provider->getConfig('locale'));
+		$this->assertSame('MyApp/1.0', $provider->getConfig('userAgent'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDefaultConfig(): void {
+		$provider = new NominatimProvider();
+
+		$this->assertNull($provider->getConfig('apiKey'));
+		$this->assertSame('en', $provider->getConfig('locale'));
+		$this->assertSame('CakePHP-Geo-Plugin', $provider->getConfig('userAgent'));
+		$this->assertSame('https://nominatim.openstreetmap.org', $provider->getConfig('rootUrl'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCustomRootUrl(): void {
+		$provider = new NominatimProvider([
+			'rootUrl' => 'https://nominatim.example.com',
+			'userAgent' => 'CustomApp',
+		]);
+
+		$this->assertSame('https://nominatim.example.com', $provider->getConfig('rootUrl'));
+	}
+
+}

--- a/tests/TestCase/Geocoder/Provider/NullProviderTest.php
+++ b/tests/TestCase/Geocoder/Provider/NullProviderTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Geo\Test\TestCase\Geocoder\Provider;
+
+use Cake\TestSuite\TestCase;
+use Geo\Geocoder\Provider\NullProvider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+
+class NullProviderTest extends TestCase {
+
+	/**
+	 * @var \Geo\Geocoder\Provider\NullProvider
+	 */
+	protected NullProvider $provider;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->provider = new NullProvider();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetName(): void {
+		$this->assertSame('null', $this->provider->getName());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRequiresApiKey(): void {
+		$this->assertFalse($this->provider->requiresApiKey());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGeocode(): void {
+		$result = $this->provider->geocode('Berlin, Germany');
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReverse(): void {
+		$result = $this->provider->reverse(52.52, 13.405);
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGeocodeQuery(): void {
+		$query = GeocodeQuery::create('Berlin, Germany');
+		$result = $this->provider->geocodeQuery($query);
+
+		$this->assertSame(0, $result->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReverseQuery(): void {
+		$query = ReverseQuery::fromCoordinates(52.52, 13.405);
+		$result = $this->provider->reverseQuery($query);
+
+		$this->assertSame(0, $result->count());
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add provider-based engine architecture to Geocoder, similar to StaticMapHelper
- Implement GoogleProvider, NominatimProvider, GeoapifyProvider wrapping geocoder-php providers
- Add provider constants (PROVIDER_GOOGLE, PROVIDER_NOMINATIM, PROVIDER_GEOAPIFY, PROVIDER_NULL)
- Add provider registry with `registerProvider()` for custom providers
- Support provider-specific configuration via nested config keys
- Maintain full backward compatibility with callable providers

## Usage

```php
use Geo\Geocoder\Geocoder;

// Use string provider names
$geocoder = new Geocoder(['provider' => Geocoder::PROVIDER_NOMINATIM]);

// Provider-specific config in app.php
'Geocoder' => [
    'provider' => 'nominatim',
    'nominatim' => ['userAgent' => 'MyApp/1.0'],
],

// Register custom providers
Geocoder::registerProvider('custom', MyCustomProvider::class);
```

## Test plan

- [x] All existing Geocoder tests pass
- [x] New provider tests verify configuration and basic functionality
- [x] Code style check passes
- [x] PHPStan static analysis passes