### PR TITLE
Fix Geoapify URL encoding for markers and paths

### DIFF
--- a/src/StaticMap/Provider/GeoapifyProvider.php
+++ b/src/StaticMap/Provider/GeoapifyProvider.php
@@ -124,7 +124,7 @@ class GeoapifyProvider extends AbstractStaticMapProvider {
 			$parts = ['lonlat:' . $marker['lng'] . ',' . $marker['lat']];
 
 			if (!empty($marker['color'])) {
-				$parts[] = 'color:#' . $this->formatColor($marker['color']);
+				$parts[] = 'color:%23' . $this->formatColor($marker['color']);
 			}
 
 			if (!empty($marker['size'])) {
@@ -146,7 +146,7 @@ class GeoapifyProvider extends AbstractStaticMapProvider {
 			$formatted[] = implode(';', $parts);
 		}
 
-		return 'marker=' . implode('|', $formatted);
+		return 'marker=' . implode('%7C', $formatted);
 	}
 
 	/**
@@ -166,7 +166,7 @@ class GeoapifyProvider extends AbstractStaticMapProvider {
 			$pathStr = 'polyline:' . implode(',', $points);
 
 			if (!empty($path['color'])) {
-				$pathStr .= ';linecolor:#' . $this->formatColor($path['color']);
+				$pathStr .= ';linecolor:%23' . $this->formatColor($path['color']);
 			}
 
 			if (!empty($path['weight'])) {
@@ -174,13 +174,13 @@ class GeoapifyProvider extends AbstractStaticMapProvider {
 			}
 
 			if (!empty($path['fillColor'])) {
-				$pathStr .= ';fillcolor:#' . $this->formatColor($path['fillColor']);
+				$pathStr .= ';fillcolor:%23' . $this->formatColor($path['fillColor']);
 			}
 
 			$formatted[] = $pathStr;
 		}
 
-		return 'geometry=' . implode('|', $formatted);
+		return 'geometry=' . implode('%7C', $formatted);
 	}
 
 }

--- a/tests/TestCase/StaticMap/Provider/GeoapifyProviderTest.php
+++ b/tests/TestCase/StaticMap/Provider/GeoapifyProviderTest.php
@@ -105,7 +105,7 @@ class GeoapifyProviderTest extends TestCase {
 
 		$this->assertStringContainsString('marker=', $url);
 		$this->assertStringContainsString('lonlat:16.3738,48.2082', $url);
-		$this->assertStringContainsString('color:#ff0000', $url);
+		$this->assertStringContainsString('color:%23ff0000', $url); // URL-encoded #
 		$this->assertStringContainsString('text:A', $url);
 	}
 
@@ -121,7 +121,7 @@ class GeoapifyProviderTest extends TestCase {
 			],
 		);
 
-		$this->assertStringContainsString('|', $url);
+		$this->assertStringContainsString('%7C', $url); // URL-encoded |
 		$this->assertStringContainsString('lonlat:16.3738,48.2082', $url);
 		$this->assertStringContainsString('lonlat:15.4395,47.0707', $url);
 	}
@@ -147,7 +147,7 @@ class GeoapifyProviderTest extends TestCase {
 
 		$this->assertStringContainsString('geometry=', $url);
 		$this->assertStringContainsString('polyline:', $url);
-		$this->assertStringContainsString('linecolor:#0000ff', $url);
+		$this->assertStringContainsString('linecolor:%230000ff', $url); // URL-encoded #
 		$this->assertStringContainsString('linewidth:3', $url);
 	}
 


### PR DESCRIPTION
## Summary

URL-encode special characters in GeoapifyProvider that cause 400 Bad Request errors:
- `#` (hash) in colors → `%23`
- `|` (pipe) as separator → `%7C`

## Problem

Without encoding, Geoapify API returns:
```json
{"statusCode":400,"error":"Bad Request","message":"\"marker[0][1]\" does not match any of the allowed types"}
```

## Test

Before fix (fails):
```
marker=lonlat:16.37,48.20;color:#ff0000|lonlat:16.37,48.19;color:#0000ff
```

After fix (works):
```
marker=lonlat:16.37,48.20;color:%23ff0000%7Clonlat:16.37,48.19;color:%230000ff
```