### PR TITLE
Fix outdated documentation references

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -18,6 +18,6 @@ There are a few guidelines that I need contributors to follow:
 # Additional Resources
 
 * [Coding standards guide (extending/overwriting the CakePHP ones)](https://github.com/php-fig-rectified/fig-rectified-standards/)
-* [CakePHP coding standards](https://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html)
+* [CakePHP coding standards](https://book.cakephp.org/5/en/contributing/cakephp-coding-conventions.html)
 * [General GitHub documentation](https://help.github.com/)
 * [GitHub pull request documentation](https://help.github.com/send-pull-requests/)

--- a/docs/Helper/GoogleMap.md
+++ b/docs/Helper/GoogleMap.md
@@ -130,7 +130,7 @@ Don't forget to output the buffered JS at the end of your page, where also the o
 ```html
 echo $this->fetch('script');
 ```
-This code snippet is usually already in your `layout.ctp` at the end of the body tag.
+This code snippet is usually already in your `layout.php` at the end of the body tag.
 
 ### Inline JS
 Maybe you need inline JS instead, then you can call script() instead of finalize() directly:

--- a/docs/Model/GeocodedAddresses.md
+++ b/docs/Model/GeocodedAddresses.md
@@ -29,7 +29,7 @@ Remember to add the Type mapping of `Geo\Database\Type\ObjectType` in your boots
 ```php
 TypeFactory::map('object', 'Geo\Database\Type\ObjectType');
 ```
-(see cookbook: https://book.cakephp.org/3.0/en/orm/database-basics.html#adding-custom-types)
+(see cookbook: https://book.cakephp.org/5/en/orm/database-basics.html#adding-custom-types)
 
 If you need more complex solutions, you can also manually put the Geocoder and the GeocodedAddresses Table classes together.
 


### PR DESCRIPTION
## Summary

- Update CakePHP 3.x documentation links to 5.x
- Update `layout.ctp` reference to `layout.php`