### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/GeocodedAddresses/edit.php
+++ b/templates/Admin/GeocodedAddresses/edit.php
@@ -3,14 +3,21 @@
  * @var \App\View\AppView $this
  * @var \Geo\Model\Entity\GeocodedAddress $geocodedAddress
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
         <li class="heading"><?= __('Actions') ?></li>
-        <li><?= $this->Form->postLink(
+        <li><?= $this->Form->postButton(
                 __('Delete'),
                 ['action' => 'delete', $geocodedAddress->id],
-                ['confirm' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id)]
+                [
+                    'class' => 'btn btn-link text-start w-100',
+                    'form' => [
+                        'class' => 'd-inline',
+                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id),
+                    ],
+                ]
             )
         ?></li>
         <li><?= $this->Html->link(__('List Geocoded Addresses'), ['action' => 'index']) ?></li>
@@ -32,3 +39,12 @@
     <?= $this->Form->button(__('Submit')) ?>
     <?= $this->Form->end() ?>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>

--- a/templates/Admin/GeocodedAddresses/index.php
+++ b/templates/Admin/GeocodedAddresses/index.php
@@ -6,14 +6,27 @@
  */
 use Cake\Core\Plugin;
 
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
         <li class="heading"><?= __('Actions') ?></li>
 		<li><?= $this->Html->link(__('Overview'), ['controller' => 'Geo', 'action' => 'index']) ?></li>
-        <li><?= $this->Form->postLink(__('Clear empty Geocoded Addresses'), ['action' => 'clearEmpty'], ['confirm' => 'Sure?']) ?></li>
-		<li><?= $this->Form->postLink(__('Clear all Geocoded Addresses'), ['action' => 'clearAll'], ['confirm' => 'Sure?']) ?></li>
+        <li><?= $this->Form->postButton(__('Clear empty Geocoded Addresses'), ['action' => 'clearEmpty'], [
+            'class' => 'btn btn-link text-start w-100',
+            'form' => [
+                'class' => 'd-inline',
+                'data-confirm-message' => 'Sure?',
+            ],
+        ]) ?></li>
+		<li><?= $this->Form->postButton(__('Clear all Geocoded Addresses'), ['action' => 'clearAll'], [
+            'class' => 'btn btn-link text-start w-100',
+            'form' => [
+                'class' => 'd-inline',
+                'data-confirm-message' => 'Sure?',
+            ],
+        ]) ?></li>
     </ul>
 </nav>
 <div class="content action-index index large-9 medium-8 columns col-sm-8 col-xs-12">
@@ -38,7 +51,14 @@ use Cake\Core\Plugin;
                 <td class="actions">
                 <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('view') : __('View'), ['action' => 'view', $geocodedAddress->id], ['escapeTitle' => false]); ?>
                 <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('edit') : __('Edit'), ['action' => 'edit', $geocodedAddress->id], ['escapeTitle' => false]); ?>
-                <?= $this->Form->postLink(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $geocodedAddress->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id)]); ?>
+                <?= $this->Form->postButton(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $geocodedAddress->id], [
+                    'escapeTitle' => false,
+                    'class' => 'btn btn-link p-0 align-baseline',
+                    'form' => [
+                        'class' => 'd-inline',
+                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id),
+                    ],
+                ]); ?>
                 </td>
             </tr>
             <?php endforeach; ?>
@@ -47,3 +67,12 @@ use Cake\Core\Plugin;
 
     <?php echo Plugin::isLoaded('Tools') ? $this->element('Tools.pagination') : $this->element('pagination'); ?>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>

--- a/templates/Admin/GeocodedAddresses/view.php
+++ b/templates/Admin/GeocodedAddresses/view.php
@@ -3,12 +3,19 @@
  * @var \App\View\AppView $this
  * @var \Geo\Model\Entity\GeocodedAddress $geocodedAddress
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
         <li class="heading"><?= __('Actions') ?></li>
         <li><?= $this->Html->link(__('Edit Geocoded Address'), ['action' => 'edit', $geocodedAddress->id]) ?> </li>
-        <li><?= $this->Form->postLink(__('Delete Geocoded Address'), ['action' => 'delete', $geocodedAddress->id], ['confirm' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id)]) ?> </li>
+        <li><?= $this->Form->postButton(__('Delete Geocoded Address'), ['action' => 'delete', $geocodedAddress->id], [
+            'class' => 'btn btn-link text-start w-100',
+            'form' => [
+                'class' => 'd-inline',
+                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id),
+            ],
+        ]) ?> </li>
         <li><?= $this->Html->link(__('List Geocoded Addresses'), ['action' => 'index']) ?> </li>
     </ul>
 </nav>
@@ -38,3 +45,12 @@
     </table>
 
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>


### PR DESCRIPTION
## Summary

- Replace 5 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message`.
- Add nonce-aware inline `<script>` blocks that delegate confirmation handling via `form[data-confirm-message]`.

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- Replace 5 `Form->postLink` calls across `index.php`, `edit.php`, `view.php` with `Form->postButton` (preserves the confirmation UX via `form[data-confirm-message]` + a JS delegate).
- Add 3 inline `<script>` blocks with `nonce` (one per admin template) that attach the delegated `submit` listener.

The plugin has no dedicated layout, so the delegate lives in the individual admin templates that render `postButton` forms.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink('Clear empty Geocoded Addresses', [...], ['confirm' => 'Sure?']) ?>
+ <?= $this->Form->postButton('Clear empty Geocoded Addresses', [...], [
+     'class' => 'btn btn-link text-start w-100',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => 'Sure?',
+     ],
+ ]) ?>
```
