### PR TITLE
Sanitize API key in exception, harden helper output

### DIFF
--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -269,7 +269,10 @@ class Geocoder {
 		} catch (CollectionIsEmpty $e) {
 			throw new InconclusiveException(sprintf('Inconclusive result (total of %s)', 0), 0, $e);
 		} catch (InvalidServerResponse $e) {
-			throw new RuntimeException(sprintf('Problem with API key `%s`', $this->getConfig('apiKey')) . ': ' . $e->getMessage(), 0, $e);
+			$apiKey = $this->getConfig('apiKey');
+			$hint = $apiKey ? '***' . substr((string)$apiKey, -4) : '(empty)';
+
+			throw new RuntimeException(sprintf('Problem with API key %s: %s', $hint, $e->getMessage()), 0, $e);
 		}
 
 		if (!$this->_config['allowInconclusive'] && !$this->isConclusive($result)) {

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -632,9 +632,9 @@ function geocodeAddress(address) {
 			if (!isset($options['address'])) {
 				throw new CakeException('Either use lat/lng or address to add a marker');
 			}
-			$position = 'geocodeAddress("' . h($options['address']) . '")';
+			$position = 'geocodeAddress(' . json_encode((string)$options['address']) . ')';
 		} else {
-			$position = 'new google.maps.LatLng(' . $options['lat'] . ',' . $options['lng'] . ')';
+			$position = 'new google.maps.LatLng(' . sprintf('%F', (float)$options['lat']) . ',' . sprintf('%F', (float)$options['lng']) . ')';
 		}
 
 		$marker = "
@@ -713,22 +713,26 @@ function geocodeAddress(address) {
 		if (empty($options['to']) && empty($options['from'])) {
 			return '';
 		}
+		$escape = (bool)$options['escape'];
 		$form = '<form action="https://maps.google.com/maps" method="get" target="_blank">';
-		$form .= $options['escape'] ? h($options['label']) : $options['label'];
+		$form .= $escape ? h($options['label']) : $options['label'];
 		if (!empty($options['from'])) {
-			$form .= '<input type="hidden" name="saddr" value="' . $options['from'] . '" />';
+			$from = $escape ? h($options['from']) : $options['from'];
+			$form .= '<input type="hidden" name="saddr" value="' . $from . '" />';
 		} else {
 			$form .= '<input type="text" name="saddr" />';
 		}
 		if (!empty($options['to'])) {
-			$form .= '<input type="hidden" name="daddr" value="' . $options['to'] . '" />';
+			$to = $escape ? h($options['to']) : $options['to'];
+			$form .= '<input type="hidden" name="daddr" value="' . $to . '" />';
 		} else {
 			$form .= '<input type="text" name="daddr" />';
 		}
 		if (isset($options['zoom'])) {
-			$form .= '<input type="hidden" name="z" value="' . $options['zoom'] . '" />';
+			$form .= '<input type="hidden" name="z" value="' . (int)$options['zoom'] . '" />';
 		}
-		$form .= '<input type="submit" value="' . $options['submit'] . '" />';
+		$submit = $escape ? h($options['submit']) : $options['submit'];
+		$form .= '<input type="submit" value="' . $submit . '" />';
 		$form .= '</form>';
 
 		return '<div class="directions">' . $form . '</div>';


### PR DESCRIPTION
## Summary

- The geocoder no longer embeds the raw provider API key in the `RuntimeException` it throws on `InvalidServerResponse`. The message now shows only a four-character suffix with a fixed prefix, so the credential cannot leak through logs, debug pages, or error reporters that surface exception messages.
- `GoogleMapHelper::_directions()` now honors the existing `escape` default for the `from`, `to`, and `submit` fields and casts `zoom` to `int`, closing an HTML injection path when a caller wires user input into the directions form.
- `GoogleMapHelper::addMarker()` now coerces `lat`/`lng` to `float` and emits them via `sprintf('%F', ...)` for locale-safe formatting, and JSON-encodes the `address` string so a quoted payload cannot break out of the inline `<script>` block.

## Notes

No behavior change for callers passing well-formed numeric coordinates and trusted text. Full test suite (281 tests) green; phpstan and phpcs clean on the touched files.