### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/geo.pot
+++ b/resources/locales/geo.pot
@@ -1,0 +1,154 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 03:17+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "The empty geocoded addresses have been removed from cache."
+msgstr ""
+
+msgid "All geocoded addresses have been removed from cache"
+msgstr ""
+
+msgid "The geocoded address has been saved."
+msgstr ""
+
+msgid "The geocoded address could not be saved. Please, try again."
+msgstr ""
+
+msgid "The geocoded address has been deleted."
+msgstr ""
+
+msgid "The geocoded address could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Country"
+msgstr ""
+
+msgid "Province"
+msgstr ""
+
+msgid "Sub Province"
+msgstr ""
+
+msgid "Region"
+msgstr ""
+
+msgid "Sub Region"
+msgstr ""
+
+msgid "Locality"
+msgstr ""
+
+msgid "Sub Locality"
+msgstr ""
+
+msgid "Postal Code"
+msgstr ""
+
+msgid "Street Address"
+msgstr ""
+
+msgid "Street Number"
+msgstr ""
+
+msgid "Could not geocode this address. Please refine."
+msgstr ""
+
+msgid "Map cannot be displayed!"
+msgstr ""
+
+msgid "Enter your address"
+msgstr ""
+
+msgid "Get directions"
+msgstr ""
+
+msgid "Map"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "List Geocoded Addresses"
+msgstr ""
+
+msgid "Geocode {0}"
+msgstr ""
+
+msgid "Address"
+msgstr ""
+
+msgid "Geocode"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "Edit Geocoded Address"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Overview"
+msgstr ""
+
+msgid "Clear empty Geocoded Addresses"
+msgstr ""
+
+msgid "Clear all Geocoded Addresses"
+msgstr ""
+
+msgid "Geocoded Addresses"
+msgstr ""
+
+msgid "Coordinates"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Delete Geocoded Address"
+msgstr ""
+
+msgid "Formatted Address"
+msgstr ""
+
+msgid "Data"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "first"
+msgstr ""
+
+msgid "last"
+msgstr ""
+
+msgid "previous"
+msgstr ""
+
+msgid "next"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+

--- a/src/Controller/Admin/GeocodedAddressesController.php
+++ b/src/Controller/Admin/GeocodedAddressesController.php
@@ -45,7 +45,7 @@ class GeocodedAddressesController extends AppController {
 
 		$this->GeocodedAddresses->clearEmpty();
 
-		$this->Flash->success(__('The empty geocoded addresses have been removed from cache.'));
+		$this->Flash->success(__d('geo', 'The empty geocoded addresses have been removed from cache.'));
 
 		return $this->redirect(['action' => 'index']);
 	}
@@ -58,7 +58,7 @@ class GeocodedAddressesController extends AppController {
 
 		$this->GeocodedAddresses->clearAll();
 
-		$this->Flash->success(__('All geocoded addresses have been removed from cache'));
+		$this->Flash->success(__d('geo', 'All geocoded addresses have been removed from cache'));
 
 		return $this->redirect(['action' => 'index']);
 	}
@@ -75,11 +75,11 @@ class GeocodedAddressesController extends AppController {
 		if ($this->request->is(['patch', 'post', 'put'])) {
 			$geocodedAddress = $this->GeocodedAddresses->patchEntity($geocodedAddress, $this->request->getData());
 			if ($this->GeocodedAddresses->save($geocodedAddress)) {
-				$this->Flash->success(__('The geocoded address has been saved.'));
+				$this->Flash->success(__d('geo', 'The geocoded address has been saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('The geocoded address could not be saved. Please, try again.'));
+			$this->Flash->error(__d('geo', 'The geocoded address could not be saved. Please, try again.'));
 		}
 		$this->set(compact('geocodedAddress'));
 	}
@@ -95,9 +95,9 @@ class GeocodedAddressesController extends AppController {
 		$this->request->allowMethod(['post', 'delete']);
 		$geocodedAddress = $this->GeocodedAddresses->get($id);
 		if ($this->GeocodedAddresses->delete($geocodedAddress)) {
-			$this->Flash->success(__('The geocoded address has been deleted.'));
+			$this->Flash->success(__d('geo', 'The geocoded address has been deleted.'));
 		} else {
-			$this->Flash->error(__('The geocoded address could not be deleted. Please, try again.'));
+			$this->Flash->error(__d('geo', 'The geocoded address could not be deleted. Please, try again.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -233,16 +233,16 @@ class Geocoder {
 	 */
 	public function accuracyTypes() {
 		$array = [
-			static::TYPE_COUNTRY => __('Country'),
-			static::TYPE_AAL1 => __('Province'),
-			static::TYPE_AAL3 => __('Sub Province'),
-			static::TYPE_AAL4 => __('Region'),
-			static::TYPE_AAL5 => __('Sub Region'),
-			static::TYPE_LOC => __('Locality'),
-			static::TYPE_SUBLOC => __('Sub Locality'),
-			static::TYPE_POSTAL => __('Postal Code'),
-			static::TYPE_ADDRESS => __('Street Address'),
-			static::TYPE_NUMBER => __('Street Number'),
+			static::TYPE_COUNTRY => __d('geo', 'Country'),
+			static::TYPE_AAL1 => __d('geo', 'Province'),
+			static::TYPE_AAL3 => __d('geo', 'Sub Province'),
+			static::TYPE_AAL4 => __d('geo', 'Region'),
+			static::TYPE_AAL5 => __d('geo', 'Sub Region'),
+			static::TYPE_LOC => __d('geo', 'Locality'),
+			static::TYPE_SUBLOC => __d('geo', 'Sub Locality'),
+			static::TYPE_POSTAL => __d('geo', 'Postal Code'),
+			static::TYPE_ADDRESS => __d('geo', 'Street Address'),
+			static::TYPE_NUMBER => __d('geo', 'Street Number'),
 		];
 
 		return $array;

--- a/src/Model/Behavior/GeocoderBehavior.php
+++ b/src/Model/Behavior/GeocoderBehavior.php
@@ -714,7 +714,7 @@ class GeocoderBehavior extends Behavior {
 	 * @return void
 	 */
 	protected function invalidate($entity) {
-		$errorMessage = $this->_config['validationError'] ?? __('Could not geocode this address. Please refine.');
+		$errorMessage = $this->_config['validationError'] ?? __d('geo', 'Could not geocode this address. Please refine.');
 		if ($errorMessage === false) {
 			return;
 		}

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -532,7 +532,7 @@ class GoogleMapHelper extends Helper {
 		unset($this->_runtimeConfig['div']['width']);
 		unset($this->_runtimeConfig['div']['height']);
 
-		$defaultText = $this->_runtimeConfig['content'] ?? __('Map cannot be displayed!');
+		$defaultText = $this->_runtimeConfig['content'] ?? __d('geo', 'Map cannot be displayed!');
 		$result .= $this->Html->tag('div', $defaultText, $this->_runtimeConfig['div']);
 
 		return $result;
@@ -700,8 +700,8 @@ function geocodeAddress(address) {
 		$options = [
 			'from' => null,
 			'to' => null,
-			'label' => __('Enter your address'),
-			'submit' => __('Get directions'),
+			'label' => __d('geo', 'Enter your address'),
+			'submit' => __d('geo', 'Get directions'),
 			'escape' => true,
 			'zoom' => null, // auto
 		];
@@ -1439,7 +1439,7 @@ function geocodeAddress(address) {
 	 * @return string imageTag
 	 */
 	public function staticMap(array $options = [], array $attributes = []) {
-		$defaultAttributes = ['alt' => __d('tools', 'Map')];
+		$defaultAttributes = ['alt' => __d('geo', 'Map')];
 		$attributes += $defaultAttributes;
 
 		return $this->Html->image($this->staticMapUrl($options + ['escape' => false]), $attributes);

--- a/src/View/Helper/LeafletHelper.php
+++ b/src/View/Helper/LeafletHelper.php
@@ -346,7 +346,7 @@ class LeafletHelper extends Helper {
 		$divOptions['style'] .= 'height: ' . $divOptions['height'] . ';';
 		unset($divOptions['width'], $divOptions['height']);
 
-		$defaultText = $this->_runtimeConfig['content'] ?? __('Map cannot be displayed!');
+		$defaultText = $this->_runtimeConfig['content'] ?? __d('geo', 'Map cannot be displayed!');
 		$result .= $this->Html->tag('div', $defaultText, $divOptions);
 
 		return $result;

--- a/templates/Admin/Geo/index.php
+++ b/templates/Admin/Geo/index.php
@@ -7,8 +7,8 @@
 
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
 	<ul class="side-nav nav nav-pills nav-stacked">
-		<li class="heading"><?= __('Actions') ?></li>
-		<li><?= $this->Html->link(__('List Geocoded Addresses'), ['controller' => 'GeocodedAddresses', 'action' => 'index']) ?></li>
+		<li class="heading"><?= __d('geo', 'Actions') ?></li>
+		<li><?= $this->Html->link(__d('geo', 'List Geocoded Addresses'), ['controller' => 'GeocodedAddresses', 'action' => 'index']) ?></li>
 	</ul>
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
@@ -19,14 +19,14 @@
 <h2>Geocode</h2>
 <?= $this->Form->create() ?>
 <fieldset>
-	<legend><?= __('Geocode {0}', __('Address')) ?></legend>
+	<legend><?= __d('geo', 'Geocode {0}', __d('geo', 'Address')) ?></legend>
 	<?php
 	echo $this->Form->control('address');
 	echo $this->Form->control('reset_cache', ['type' => 'checkbox']);
 
 	?>
 </fieldset>
-<?= $this->Form->button(__('Geocode')) ?>
+<?= $this->Form->button(__d('geo', 'Geocode')) ?>
 <?= $this->Form->end() ?>
 
 

--- a/templates/Admin/GeocodedAddresses/edit.php
+++ b/templates/Admin/GeocodedAddresses/edit.php
@@ -7,27 +7,27 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
-        <li class="heading"><?= __('Actions') ?></li>
+        <li class="heading"><?= __d('geo', 'Actions') ?></li>
         <li><?= $this->Form->postButton(
-                __('Delete'),
+                __d('geo', 'Delete'),
                 ['action' => 'delete', $geocodedAddress->id],
                 [
                     'class' => 'btn btn-link text-start w-100',
                     'form' => [
                         'class' => 'd-inline',
-                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id),
+                        'data-confirm-message' => __d('geo', 'Are you sure you want to delete # {0}?', $geocodedAddress->id),
                     ],
                 ]
             )
         ?></li>
-        <li><?= $this->Html->link(__('List Geocoded Addresses'), ['action' => 'index']) ?></li>
+        <li><?= $this->Html->link(__d('geo', 'List Geocoded Addresses'), ['action' => 'index']) ?></li>
     </ul>
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
-	<h1><?= __('Edit Geocoded Address') ?></h1>
+	<h1><?= __d('geo', 'Edit Geocoded Address') ?></h1>
     <?= $this->Form->create($geocodedAddress) ?>
     <fieldset>
-        <legend><?= __('Edit Geocoded Address') ?></legend>
+        <legend><?= __d('geo', 'Edit Geocoded Address') ?></legend>
         <?php
             echo $this->Form->control('address');
             echo $this->Form->control('formatted_address');
@@ -36,7 +36,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             echo $this->Form->control('lng');
         ?>
     </fieldset>
-    <?= $this->Form->button(__('Submit')) ?>
+    <?= $this->Form->button(__d('geo', 'Submit')) ?>
     <?= $this->Form->end() ?>
 </div>
 <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>

--- a/templates/Admin/GeocodedAddresses/index.php
+++ b/templates/Admin/GeocodedAddresses/index.php
@@ -11,16 +11,16 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
-        <li class="heading"><?= __('Actions') ?></li>
-		<li><?= $this->Html->link(__('Overview'), ['controller' => 'Geo', 'action' => 'index']) ?></li>
-        <li><?= $this->Form->postButton(__('Clear empty Geocoded Addresses'), ['action' => 'clearEmpty'], [
+        <li class="heading"><?= __d('geo', 'Actions') ?></li>
+		<li><?= $this->Html->link(__d('geo', 'Overview'), ['controller' => 'Geo', 'action' => 'index']) ?></li>
+        <li><?= $this->Form->postButton(__d('geo', 'Clear empty Geocoded Addresses'), ['action' => 'clearEmpty'], [
             'class' => 'btn btn-link text-start w-100',
             'form' => [
                 'class' => 'd-inline',
                 'data-confirm-message' => 'Sure?',
             ],
         ]) ?></li>
-		<li><?= $this->Form->postButton(__('Clear all Geocoded Addresses'), ['action' => 'clearAll'], [
+		<li><?= $this->Form->postButton(__d('geo', 'Clear all Geocoded Addresses'), ['action' => 'clearAll'], [
             'class' => 'btn btn-link text-start w-100',
             'form' => [
                 'class' => 'd-inline',
@@ -30,15 +30,15 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
     </ul>
 </nav>
 <div class="content action-index index large-9 medium-8 columns col-sm-8 col-xs-12">
-    <h1><?= __('Geocoded Addresses') ?></h1>
+    <h1><?= __d('geo', 'Geocoded Addresses') ?></h1>
     <table class="table table-striped">
         <thead>
             <tr>
                 <th><?= $this->Paginator->sort('address') ?></th>
                 <th><?= $this->Paginator->sort('formatted_address') ?></th>
                 <th><?= $this->Paginator->sort('country') ?></th>
-                <th><?= __('Coordinates') ?></th>
-                <th class="actions"><?= __('Actions') ?></th>
+                <th><?= __d('geo', 'Coordinates') ?></th>
+                <th class="actions"><?= __d('geo', 'Actions') ?></th>
             </tr>
         </thead>
         <tbody>
@@ -49,14 +49,14 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                 <td><?= h($geocodedAddress->country) ?></td>
                 <td><?= $geocodedAddress->lat && $geocodedAddress->lng ? $this->Number->format($geocodedAddress->lat) . ' / ' . $this->Number->format($geocodedAddress->lng) : '-' ?></td>
                 <td class="actions">
-                <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('view') : __('View'), ['action' => 'view', $geocodedAddress->id], ['escapeTitle' => false]); ?>
-                <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('edit') : __('Edit'), ['action' => 'edit', $geocodedAddress->id], ['escapeTitle' => false]); ?>
-                <?= $this->Form->postButton(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $geocodedAddress->id], [
+                <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('view') : __d('geo', 'View'), ['action' => 'view', $geocodedAddress->id], ['escapeTitle' => false]); ?>
+                <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('edit') : __d('geo', 'Edit'), ['action' => 'edit', $geocodedAddress->id], ['escapeTitle' => false]); ?>
+                <?= $this->Form->postButton(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __d('geo', 'Delete'), ['action' => 'delete', $geocodedAddress->id], [
                     'escapeTitle' => false,
                     'class' => 'btn btn-link p-0 align-baseline',
                     'form' => [
                         'class' => 'd-inline',
-                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id),
+                        'data-confirm-message' => __d('geo', 'Are you sure you want to delete # {0}?', $geocodedAddress->id),
                     ],
                 ]); ?>
                 </td>

--- a/templates/Admin/GeocodedAddresses/view.php
+++ b/templates/Admin/GeocodedAddresses/view.php
@@ -7,39 +7,39 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills nav-stacked">
-        <li class="heading"><?= __('Actions') ?></li>
-        <li><?= $this->Html->link(__('Edit Geocoded Address'), ['action' => 'edit', $geocodedAddress->id]) ?> </li>
-        <li><?= $this->Form->postButton(__('Delete Geocoded Address'), ['action' => 'delete', $geocodedAddress->id], [
+        <li class="heading"><?= __d('geo', 'Actions') ?></li>
+        <li><?= $this->Html->link(__d('geo', 'Edit Geocoded Address'), ['action' => 'edit', $geocodedAddress->id]) ?> </li>
+        <li><?= $this->Form->postButton(__d('geo', 'Delete Geocoded Address'), ['action' => 'delete', $geocodedAddress->id], [
             'class' => 'btn btn-link text-start w-100',
             'form' => [
                 'class' => 'd-inline',
-                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $geocodedAddress->id),
+                'data-confirm-message' => __d('geo', 'Are you sure you want to delete # {0}?', $geocodedAddress->id),
             ],
         ]) ?> </li>
-        <li><?= $this->Html->link(__('List Geocoded Addresses'), ['action' => 'index']) ?> </li>
+        <li><?= $this->Html->link(__d('geo', 'List Geocoded Addresses'), ['action' => 'index']) ?> </li>
     </ul>
 </nav>
 <div class="content action-view view large-9 medium-8 columns col-sm-8 col-xs-12">
     <h1><?= h($geocodedAddress->address) ?></h1>
     <table class="table vertical-table">
         <tr>
-            <th><?= __('Formatted Address') ?></th>
+            <th><?= __d('geo', 'Formatted Address') ?></th>
             <td><?= h($geocodedAddress->formatted_address) ?></td>
         </tr>
         <tr>
-            <th><?= __('Country') ?></th>
+            <th><?= __d('geo', 'Country') ?></th>
             <td><?= h($geocodedAddress->country) ?></td>
         </tr>
         <tr>
-            <th><?= __('Coordinates') ?></th>
+            <th><?= __d('geo', 'Coordinates') ?></th>
             <td><?= $geocodedAddress->lat && $geocodedAddress->lng ? $this->Number->format($geocodedAddress->lat) . ' / ' . $this->Number->format($geocodedAddress->lng) : '-' ?></td>
         </tr>
         <tr>
-            <th><?= __('Data') ?></th>
+            <th><?= __d('geo', 'Data') ?></th>
             <td><?= $geocodedAddress->data ? '<pre>' . h(print_r($geocodedAddress->data->toArray(), true)) . '</pre>' : '-' ?></td>
         </tr>
 		<tr>
-			<th><?= __('Created') ?></th>
+			<th><?= __d('geo', 'Created') ?></th>
 			<td><?= $this->Time->nice($geocodedAddress->created) ?></td>
 		</tr>
     </table>

--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -14,19 +14,19 @@ if (!isset($separator)) {
 }
 
 if (empty($first)) {
-	$first = __d('tools', 'first');
+	$first = __d('geo', 'first');
 }
 if (empty($last)) {
-	$last = __d('tools', 'last');
+	$last = __d('geo', 'last');
 }
 if (empty($prev)) {
-	$prev = __d('tools', 'previous');
+	$prev = __d('geo', 'previous');
 }
 if (empty($next)) {
-	$next = __d('tools', 'next');
+	$next = __d('geo', 'next');
 }
 if (!isset($format)) {
-	$format = __d('tools', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total');
+	$format = __d('geo', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total');
 }
 if (!empty($reverse)) {
 	$tmp = $first;


### PR DESCRIPTION
## Summary

- Convert 53 `__()` calls across `src/` and `templates/` to `__d('geo', ...)` so plugin strings live in their own domain.
- Re-route the 6 pre-existing `__d('tools', ...)` calls (1 in `GoogleMapHelper::map()` alt-text, 5 in `templates/element/pagination.php`) to `__d('geo', ...)`. These were leftovers from when the relevant code was copied from `cakephp-tools` — the plugin should own its own strings.
- The 1 pre-existing `__d('geo', ...)` call in `StaticMapHelper` already pointed at the right domain.
- Add `resources/locales/geo.pot` (46 unique msgids) generated via `bin/cake i18n extract`.

## Why

Plugin strings were either landing in the host app's `default` domain (53 calls) or in a sibling plugin's `tools` domain (6 calls). Either way, anyone wanting to ship a German/Japanese/etc. language pack with `cakephp-geo` couldn't, because the strings weren't owned by this plugin.

## Verification (local)

- phpunit: 281 / 281 (11 pre-existing notices, 7 skipped — unrelated to this change)
- phpstan: no errors
- phpcs: clean