### PR TITLE
Add GeoJSON geometry value objects for Leaflet

### DIFF
--- a/docs/Geometry/GeoJson.md
+++ b/docs/Geometry/GeoJson.md
@@ -1,0 +1,90 @@
+# GeoJSON Geometry
+
+The plugin now provides lightweight GeoJSON value objects you can use instead of passing raw arrays everywhere.
+
+Available classes:
+- `Geo\Geometry\Point`
+- `Geo\Geometry\Polygon`
+- `Geo\Geometry\Feature`
+- `Geo\Geometry\FeatureCollection`
+
+## Point
+
+```php
+use Geo\Geometry\Point;
+
+$point = new Point(16.3738, 48.2082); // lng, lat
+
+$point->toGeoJsonArray();
+// ['type' => 'Point', 'coordinates' => [16.3738, 48.2082]]
+
+$point->toLatLngArray();
+// ['lat' => 48.2082, 'lng' => 16.3738]
+```
+
+You can also construct it from the more common Leaflet-style ordering:
+
+```php
+$point = Point::fromLatLng(48.2082, 16.3738);
+```
+
+## Polygon
+
+GeoJSON uses `[lng, lat]` coordinate pairs and supports one outer ring plus optional inner rings (holes).
+
+```php
+use Geo\Geometry\Polygon;
+
+$polygon = new Polygon([
+    [
+        [16.3, 48.2],
+        [16.4, 48.3],
+        [16.5, 48.1],
+        [16.3, 48.2],
+    ],
+]);
+```
+
+If your application already works with `lat`/`lng` arrays, use the convenience constructor:
+
+```php
+$polygon = Polygon::fromLatLngPoints([
+    ['lat' => 48.2, 'lng' => 16.3],
+    ['lat' => 48.3, 'lng' => 16.4],
+    ['lat' => 48.1, 'lng' => 16.5],
+]);
+```
+
+That helper automatically closes the outer ring if the last point is missing.
+
+## Feature / FeatureCollection
+
+```php
+use Geo\Geometry\Feature;
+use Geo\Geometry\FeatureCollection;
+use Geo\Geometry\Point;
+
+$collection = new FeatureCollection([
+    new Feature(new Point(16.3738, 48.2082), ['name' => 'Vienna']),
+]);
+```
+
+## Using the objects with Leaflet
+
+`LeafletHelper::addGeoJson()` now accepts:
+- raw GeoJSON arrays
+- GeoJSON strings
+- any `GeoJsonInterface` implementation
+
+```php
+$this->Leaflet->addGeoJson($collection);
+```
+
+`LeafletHelper::addPolygon()` also accepts a `Polygon` object directly:
+
+```php
+$this->Leaflet->addPolygon($polygon, [
+    'color' => '#ff0000',
+    'fillOpacity' => 0.4,
+]);
+```

--- a/docs/Helper/Leaflet.md
+++ b/docs/Helper/Leaflet.md
@@ -214,6 +214,10 @@ $this->Leaflet->addPolygon($points, [
 
 ## GeoJSON support
 ```php
+use Geo\Geometry\Feature;
+use Geo\Geometry\FeatureCollection;
+use Geo\Geometry\Point;
+
 $geoJson = [
     'type' => 'FeatureCollection',
     'features' => [
@@ -230,6 +234,33 @@ $geoJson = [
     ],
 ];
 $this->Leaflet->addGeoJson($geoJson);
+```
+
+You can also pass the plugin's GeoJSON value objects directly:
+
+```php
+$collection = new FeatureCollection([
+    new Feature(new Point(16.3738, 48.2082), ['name' => 'Vienna']),
+]);
+
+$this->Leaflet->addGeoJson($collection);
+```
+
+And `addPolygon()` now accepts a `Geo\Geometry\Polygon` object:
+
+```php
+use Geo\Geometry\Polygon;
+
+$polygon = Polygon::fromLatLngPoints([
+    ['lat' => 48.2, 'lng' => 16.3],
+    ['lat' => 48.3, 'lng' => 16.4],
+    ['lat' => 48.1, 'lng' => 16.5],
+]);
+
+$this->Leaflet->addPolygon($polygon, [
+    'color' => '#ff0000',
+    'fillOpacity' => 0.5,
+]);
 ```
 
 ## Multiple maps per page

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 * [Geocoder lib](Geocoder/Geocoder.md)
 * [Calculator lib](Geocoder/Calculator.md)
 * [Geo lib](Geocoder/Geo.md)
+* [GeoJSON geometry](Geometry/GeoJson.md)
 * [GoogleMap helper](Helper/GoogleMap.md)
 * [Leaflet helper](Helper/Leaflet.md)
 * [Leaflet tile providers](Helper/LeafletTileProviders.md)

--- a/src/Geometry/Feature.php
+++ b/src/Geometry/Feature.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Geo\Geometry;
+
+class Feature implements GeoJsonInterface {
+
+	protected GeoJsonInterface $geometry;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $properties;
+
+	/**
+	 * @param \Geo\Geometry\GeoJsonInterface $geometry
+	 * @param array<string, mixed> $properties
+	 */
+	public function __construct(GeoJsonInterface $geometry, array $properties = []) {
+		$this->geometry = $geometry;
+		$this->properties = $properties;
+	}
+
+	public function getGeometry(): GeoJsonInterface {
+		return $this->geometry;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function getProperties(): array {
+		return $this->properties;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toGeoJsonArray(): array {
+		return [
+			'type' => 'Feature',
+			'geometry' => $this->geometry->toGeoJsonArray(),
+			'properties' => $this->properties,
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return $this->toGeoJsonArray();
+	}
+
+}

--- a/src/Geometry/FeatureCollection.php
+++ b/src/Geometry/FeatureCollection.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Geo\Geometry;
+
+class FeatureCollection implements GeoJsonInterface {
+
+	/**
+	 * @var array<int, \Geo\Geometry\Feature>
+	 */
+	protected array $features;
+
+	/**
+	 * @param array<int, \Geo\Geometry\Feature> $features
+	 */
+	public function __construct(array $features) {
+		$this->features = $features;
+	}
+
+	/**
+	 * @return array<int, \Geo\Geometry\Feature>
+	 */
+	public function getFeatures(): array {
+		return $this->features;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toGeoJsonArray(): array {
+		return [
+			'type' => 'FeatureCollection',
+			'features' => array_map(static fn (Feature $feature): array => $feature->toGeoJsonArray(), $this->features),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return $this->toGeoJsonArray();
+	}
+
+}

--- a/src/Geometry/GeoJsonInterface.php
+++ b/src/Geometry/GeoJsonInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Geo\Geometry;
+
+use JsonSerializable;
+
+interface GeoJsonInterface extends JsonSerializable {
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toGeoJsonArray(): array;
+
+}

--- a/src/Geometry/Point.php
+++ b/src/Geometry/Point.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Geo\Geometry;
+
+class Point implements GeoJsonInterface {
+
+	protected float $longitude;
+
+	protected float $latitude;
+
+	public function __construct(float $longitude, float $latitude) {
+		$this->longitude = $longitude;
+		$this->latitude = $latitude;
+	}
+
+	public static function fromLatLng(float $latitude, float $longitude): static {
+		return new static($longitude, $latitude);
+	}
+
+	/**
+	 * @param array{0: float|int, 1: float|int} $coordinates
+	 * @return static
+	 */
+	public static function fromCoordinates(array $coordinates): static {
+		return new static((float)$coordinates[0], (float)$coordinates[1]);
+	}
+
+	public function getLongitude(): float {
+		return $this->longitude;
+	}
+
+	public function getLatitude(): float {
+		return $this->latitude;
+	}
+
+	/**
+	 * @return array{lat: float, lng: float}
+	 */
+	public function toLatLngArray(): array {
+		return [
+			'lat' => $this->latitude,
+			'lng' => $this->longitude,
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toGeoJsonArray(): array {
+		return [
+			'type' => 'Point',
+			'coordinates' => [$this->longitude, $this->latitude],
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return $this->toGeoJsonArray();
+	}
+
+}

--- a/src/Geometry/Polygon.php
+++ b/src/Geometry/Polygon.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Geo\Geometry;
+
+class Polygon implements GeoJsonInterface {
+
+	/**
+	 * @var array<int, array<int, array{0: float, 1: float}>>
+	 */
+	protected array $rings;
+
+	/**
+	 * @param array<int, array<int, array{0: float|int, 1: float|int}>> $rings
+	 */
+	public function __construct(array $rings) {
+		$this->rings = [];
+		foreach ($rings as $ring) {
+			$this->rings[] = $this->normalizeRing($ring);
+		}
+	}
+
+	/**
+	 * @param array<int, array<string, float|int>> $points
+	 * @return static
+	 */
+	public static function fromLatLngPoints(array $points): static {
+		$ring = [];
+		foreach ($points as $point) {
+			$ring[] = [(float)$point['lng'], (float)$point['lat']];
+		}
+
+		if ($ring !== [] && $ring[0] !== $ring[count($ring) - 1]) {
+			$ring[] = $ring[0];
+		}
+
+		return new static([$ring]);
+	}
+
+	/**
+	 * @return array<int, array<int, array{0: float, 1: float}>>
+	 */
+	public function getRings(): array {
+		return $this->rings;
+	}
+
+	/**
+	 * Leaflet expects [lat, lng] pairs, GeoJSON stores [lng, lat].
+	 *
+	 * @return array<int, array<int, array{lat: float, lng: float}>>
+	 */
+	public function toLeafletRings(): array {
+		$result = [];
+		foreach ($this->rings as $ring) {
+			$result[] = array_map(function (array $coordinates): array {
+				return [
+					'lat' => $coordinates[1],
+					'lng' => $coordinates[0],
+				];
+			}, $ring);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toGeoJsonArray(): array {
+		return [
+			'type' => 'Polygon',
+			'coordinates' => $this->rings,
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return $this->toGeoJsonArray();
+	}
+
+	/**
+	 * @param array<int, array{0: float|int, 1: float|int}> $ring
+	 * @return array<int, array{0: float, 1: float}>
+	 */
+	protected function normalizeRing(array $ring): array {
+		$result = [];
+		foreach ($ring as $coordinates) {
+			$result[] = [(float)$coordinates[0], (float)$coordinates[1]];
+		}
+
+		return $result;
+	}
+
+}

--- a/src/View/Helper/LeafletHelper.php
+++ b/src/View/Helper/LeafletHelper.php
@@ -540,7 +540,7 @@ class LeafletHelper extends Helper {
 	/**
 	 * Add a polygon to the map.
 	 *
-	 * @param array<array<string, float>>|\Geo\Geometry\Polygon $points Array of lat/lng pairs or polygon object
+	 * @param \Geo\Geometry\Polygon|array<array<string, float>> $points Array of lat/lng pairs or polygon object
 	 * @param array<string, mixed> $options
 	 * @return void
 	 */
@@ -600,7 +600,7 @@ class LeafletHelper extends Helper {
 	/**
 	 * Add a GeoJSON layer to the map.
 	 *
-	 * @param array<string, mixed>|string|\Geo\Geometry\GeoJsonInterface $data GeoJSON data
+	 * @param \Geo\Geometry\GeoJsonInterface|array<string, mixed>|string $data GeoJSON data
 	 * @param array<string, mixed> $options
 	 * @return void
 	 */
@@ -799,7 +799,7 @@ jQuery(document).ready(function() {
 	}
 
 	/**
-	 * @param array<array<string, float>>|\Geo\Geometry\Polygon $points
+	 * @param \Geo\Geometry\Polygon|array<array<string, float>> $points
 	 * @return array<int, mixed>
 	 */
 	protected function _polygonJsPoints(array|Polygon $points): array {
@@ -825,7 +825,7 @@ jQuery(document).ready(function() {
 	}
 
 	/**
-	 * @param array<string, mixed>|string|\Geo\Geometry\GeoJsonInterface $data
+	 * @param \Geo\Geometry\GeoJsonInterface|array<string, mixed>|string $data
 	 * @return string
 	 */
 	protected function _geoJsonString(array|string|GeoJsonInterface $data): string {

--- a/src/View/Helper/LeafletHelper.php
+++ b/src/View/Helper/LeafletHelper.php
@@ -5,6 +5,9 @@ namespace Geo\View\Helper;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\View\Helper;
+use Geo\Geometry\GeoJsonInterface;
+use Geo\Geometry\Polygon;
+use InvalidArgumentException;
 
 /**
  * This is a CakePHP helper that helps users to integrate Leaflet.js
@@ -537,18 +540,15 @@ class LeafletHelper extends Helper {
 	/**
 	 * Add a polygon to the map.
 	 *
-	 * @param array<array<string, float>> $points Array of lat/lng pairs
+	 * @param array<array<string, float>>|\Geo\Geometry\Polygon $points Array of lat/lng pairs or polygon object
 	 * @param array<string, mixed> $options
 	 * @return void
 	 */
-	public function addPolygon(array $points, array $options = []): void {
+	public function addPolygon(array|Polygon $points, array $options = []): void {
 		$defaults = $this->_runtimeConfig['polygon'];
 		$options += $defaults;
 
-		$jsPoints = [];
-		foreach ($points as $point) {
-			$jsPoints[] = '[' . (float)$point['lat'] . ', ' . (float)$point['lng'] . ']';
-		}
+		$jsPoints = $this->_polygonJsPoints($points);
 
 		$polygonOptions = [
 			'color' => $options['color'],
@@ -557,7 +557,7 @@ class LeafletHelper extends Helper {
 		];
 
 		$polygon = '
-		L.polygon([' . implode(', ', $jsPoints) . '], ' . $this->_buildJsObject($polygonOptions) . ').addTo(' . $this->name() . ');
+		L.polygon(' . $this->_jsArray($jsPoints) . ', ' . $this->_buildJsObject($polygonOptions) . ').addTo(' . $this->name() . ');
 		';
 
 		$this->map .= $polygon;
@@ -600,12 +600,12 @@ class LeafletHelper extends Helper {
 	/**
 	 * Add a GeoJSON layer to the map.
 	 *
-	 * @param array<string, mixed> $data GeoJSON data
+	 * @param array<string, mixed>|string|\Geo\Geometry\GeoJsonInterface $data GeoJSON data
 	 * @param array<string, mixed> $options
 	 * @return void
 	 */
-	public function addGeoJson(array $data, array $options = []): void {
-		$geoJsonJs = json_encode($data);
+	public function addGeoJson(array|string|GeoJsonInterface $data, array $options = []): void {
+		$geoJsonJs = $this->_geoJsonString($data);
 
 		$optionsJs = '';
 		if ($options) {
@@ -793,6 +793,68 @@ jQuery(document).ready(function() {
 		$result = json_encode($options);
 		if ($result === false) {
 			return '{}';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param array<array<string, float>>|\Geo\Geometry\Polygon $points
+	 * @return array<int, mixed>
+	 */
+	protected function _polygonJsPoints(array|Polygon $points): array {
+		if ($points instanceof Polygon) {
+			$result = [];
+			foreach ($points->toLeafletRings() as $ring) {
+				$jsRing = [];
+				foreach ($ring as $point) {
+					$jsRing[] = [(float)$point['lat'], (float)$point['lng']];
+				}
+				$result[] = $jsRing;
+			}
+
+			return count($result) === 1 ? $result[0] : $result;
+		}
+
+		$result = [];
+		foreach ($points as $point) {
+			$result[] = [(float)$point['lat'], (float)$point['lng']];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param array<string, mixed>|string|\Geo\Geometry\GeoJsonInterface $data
+	 * @return string
+	 */
+	protected function _geoJsonString(array|string|GeoJsonInterface $data): string {
+		if ($data instanceof GeoJsonInterface) {
+			$data = $data->toGeoJsonArray();
+		} elseif (is_string($data)) {
+			$decoded = json_decode($data, true);
+			if (!is_array($decoded)) {
+				throw new InvalidArgumentException('GeoJSON string must decode to an object/array structure.');
+			}
+			$data = $decoded;
+		}
+
+		$result = json_encode($data);
+		if ($result === false) {
+			throw new InvalidArgumentException('GeoJSON data could not be encoded.');
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param array<int, mixed> $value
+	 * @return string
+	 */
+	protected function _jsArray(array $value): string {
+		$result = json_encode($value);
+		if ($result === false) {
+			return '[]';
 		}
 
 		return $result;

--- a/tests/TestCase/Geometry/GeoJsonGeometryTest.php
+++ b/tests/TestCase/Geometry/GeoJsonGeometryTest.php
@@ -21,6 +21,18 @@ class GeoJsonGeometryTest extends TestCase {
 		$this->assertSame(['lat' => 48.2082, 'lng' => 16.3738], $point->toLatLngArray());
 	}
 
+	public function testPointNamedConstructorsAndAccessors(): void {
+		$point = Point::fromLatLng(48.2082, 16.3738);
+
+		$this->assertSame(16.3738, $point->getLongitude());
+		$this->assertSame(48.2082, $point->getLatitude());
+		$this->assertSame($point->toGeoJsonArray(), $point->jsonSerialize());
+
+		$pointFromCoordinates = Point::fromCoordinates([16.4, 48.3]);
+		$this->assertSame(16.4, $pointFromCoordinates->getLongitude());
+		$this->assertSame(48.3, $pointFromCoordinates->getLatitude());
+	}
+
 	public function testPolygonFromLatLngPointsClosesRing(): void {
 		$polygon = Polygon::fromLatLngPoints([
 			['lat' => 48.2, 'lng' => 16.3],
@@ -50,6 +62,18 @@ class GeoJsonGeometryTest extends TestCase {
 		$this->assertCount(2, $result['features']);
 		$this->assertSame('Point', $result['features'][0]['geometry']['type']);
 		$this->assertSame('Polygon', $result['features'][1]['geometry']['type']);
+	}
+
+	public function testFeatureAndCollectionAccessors(): void {
+		$feature = new Feature(new Point(16.3738, 48.2082), ['name' => 'Vienna']);
+
+		$this->assertSame('Vienna', $feature->getProperties()['name']);
+		$this->assertInstanceOf(Point::class, $feature->getGeometry());
+		$this->assertSame($feature->toGeoJsonArray(), $feature->jsonSerialize());
+
+		$collection = new FeatureCollection([$feature]);
+		$this->assertCount(1, $collection->getFeatures());
+		$this->assertSame($collection->toGeoJsonArray(), $collection->jsonSerialize());
 	}
 
 }

--- a/tests/TestCase/Geometry/GeoJsonGeometryTest.php
+++ b/tests/TestCase/Geometry/GeoJsonGeometryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Geo\Test\TestCase\Geometry;
+
+use Cake\TestSuite\TestCase;
+use Geo\Geometry\Feature;
+use Geo\Geometry\FeatureCollection;
+use Geo\Geometry\Point;
+use Geo\Geometry\Polygon;
+
+class GeoJsonGeometryTest extends TestCase {
+
+	public function testPointToGeoJsonArray(): void {
+		$point = new Point(16.3738, 48.2082);
+
+		$expected = [
+			'type' => 'Point',
+			'coordinates' => [16.3738, 48.2082],
+		];
+		$this->assertSame($expected, $point->toGeoJsonArray());
+		$this->assertSame(['lat' => 48.2082, 'lng' => 16.3738], $point->toLatLngArray());
+	}
+
+	public function testPolygonFromLatLngPointsClosesRing(): void {
+		$polygon = Polygon::fromLatLngPoints([
+			['lat' => 48.2, 'lng' => 16.3],
+			['lat' => 48.3, 'lng' => 16.4],
+			['lat' => 48.1, 'lng' => 16.5],
+		]);
+
+		$coordinates = $polygon->toGeoJsonArray()['coordinates'];
+		$this->assertCount(1, $coordinates);
+		$this->assertSame([16.3, 48.2], $coordinates[0][0]);
+		$this->assertSame([16.3, 48.2], $coordinates[0][3]);
+	}
+
+	public function testFeatureCollectionToGeoJsonArray(): void {
+		$collection = new FeatureCollection([
+			new Feature(new Point(16.3738, 48.2082), ['name' => 'Vienna']),
+			new Feature(Polygon::fromLatLngPoints([
+				['lat' => 48.2, 'lng' => 16.3],
+				['lat' => 48.3, 'lng' => 16.4],
+				['lat' => 48.1, 'lng' => 16.5],
+			])),
+		]);
+
+		$result = $collection->toGeoJsonArray();
+
+		$this->assertSame('FeatureCollection', $result['type']);
+		$this->assertCount(2, $result['features']);
+		$this->assertSame('Point', $result['features'][0]['geometry']['type']);
+		$this->assertSame('Polygon', $result['features'][1]['geometry']['type']);
+	}
+
+}

--- a/tests/TestCase/View/Helper/LeafletHelperTest.php
+++ b/tests/TestCase/View/Helper/LeafletHelperTest.php
@@ -2,14 +2,15 @@
 
 namespace Geo\Test\TestCase\View\Helper;
 
-use Cake\Core\Configure;
-use Cake\TestSuite\TestCase;
-use Cake\View\View;
+	use Cake\Core\Configure;
+	use Cake\TestSuite\TestCase;
+	use Cake\View\View;
 use Geo\Geometry\Feature;
 use Geo\Geometry\FeatureCollection;
-use Geo\Geometry\Point;
-use Geo\Geometry\Polygon;
-use Geo\View\Helper\LeafletHelper;
+	use Geo\Geometry\Point;
+	use Geo\Geometry\Polygon;
+	use Geo\View\Helper\LeafletHelper;
+	use InvalidArgumentException;
 
 class LeafletHelperTest extends TestCase {
 
@@ -343,6 +344,18 @@ class LeafletHelperTest extends TestCase {
 		$result = $this->Leaflet->script();
 
 		$this->assertTextContains('"coordinates":[16.3738,48.2082]', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddGeoJsonInvalidStringThrowsException(): void {
+		$this->Leaflet->map();
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('GeoJSON string must decode to an object/array structure.');
+
+		$this->Leaflet->addGeoJson('not-json');
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/LeafletHelperTest.php
+++ b/tests/TestCase/View/Helper/LeafletHelperTest.php
@@ -5,6 +5,10 @@ namespace Geo\Test\TestCase\View\Helper;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
+use Geo\Geometry\Feature;
+use Geo\Geometry\FeatureCollection;
+use Geo\Geometry\Point;
+use Geo\Geometry\Polygon;
 use Geo\View\Helper\LeafletHelper;
 
 class LeafletHelperTest extends TestCase {
@@ -272,7 +276,24 @@ class LeafletHelperTest extends TestCase {
 
 		$result = $this->Leaflet->script();
 
-		$this->assertTextContains('L.polygon([[48.2, 16.3], [48.3, 16.4], [48.1, 16.5]]', $result);
+		$this->assertTextContains('L.polygon([[48.2,16.3],[48.3,16.4],[48.1,16.5]]', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddPolygonFromPolygonObject(): void {
+		$polygon = Polygon::fromLatLngPoints([
+			['lat' => 48.2, 'lng' => 16.3],
+			['lat' => 48.3, 'lng' => 16.4],
+			['lat' => 48.1, 'lng' => 16.5],
+		]);
+		$this->Leaflet->map();
+		$this->Leaflet->addPolygon($polygon);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('L.polygon([[48.2,16.3],[48.3,16.4],[48.1,16.5],[48.2,16.3]]', $result);
 	}
 
 	/**
@@ -293,6 +314,35 @@ class LeafletHelperTest extends TestCase {
 
 		$this->assertTextContains('L.geoJSON(', $result);
 		$this->assertTextContains('"type":"Feature"', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddGeoJsonFromFeatureCollectionObject(): void {
+		$geoJson = new FeatureCollection([
+			new Feature(new Point(16.3738, 48.2082), ['name' => 'Vienna']),
+		]);
+		$this->Leaflet->map();
+		$this->Leaflet->addGeoJson($geoJson);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('"type":"FeatureCollection"', $result);
+		$this->assertTextContains('"coordinates":[16.3738,48.2082]', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddGeoJsonFromString(): void {
+		$geoJson = '{"type":"Feature","geometry":{"type":"Point","coordinates":[16.3738,48.2082]}}';
+		$this->Leaflet->map();
+		$this->Leaflet->addGeoJson($geoJson);
+
+		$result = $this->Leaflet->script();
+
+		$this->assertTextContains('"coordinates":[16.3738,48.2082]', $result);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add lightweight GeoJSON geometry value objects for points, polygons, features, and feature collections
- extend  to accept GeoJSON objects, JSON strings, and  value objects directly
- document the new geometry layer and cover it with helper and geometry tests

## Why
The plugin already documents  and already has point/polygon rendering concepts, but usage is still mostly raw arrays. This PR gives the plugin a typed GeoJSON layer so polygon and feature support is easier to reuse, validate, and extend.

## What changed
- new 
- new , , , and  value objects
-  now accepts arrays, JSON strings, and geometry objects
-  now accepts  objects directly
- docs for GeoJSON geometry usage and Leaflet integration

## Tests
- PHPUnit 13.1.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.20
Configuration: /media/mark/data/work/devilbox/data/www/toolbox/tmp/git/cakephp-geo/phpunit.xml.dist

.................................                                 33 / 33 (100%)

Time: 00:00.021, Memory: 22.00 MB

OK (33 tests, 72 assertions)
- 
 [OK] No errors                                                                 