### PR TITLE
Fix spatial geocoding edge cases and cache misses

### DIFF
--- a/src/Geocoder/Calculator.php
+++ b/src/Geocoder/Calculator.php
@@ -120,7 +120,7 @@ class Calculator {
 	 * @param array<string, mixed> $pointX
 	 * @param array<string, mixed> $pointY
 	 * @param string|null $unit Unit char or constant (M=miles, K=kilometers, N=nautical miles, I=inches, F=feet)
-	 * @return int Distance in km
+	 * @return int Distance in the requested unit, kilometers by default
 	 */
 	public function distance(array $pointX, array $pointY, ?string $unit = null): int {
 		if (empty($unit)) {
@@ -141,9 +141,14 @@ class Calculator {
 	}
 
 	/**
+	 * Calculate the great-circle distance using the haversine formula.
+	 *
+	 * The raw return unit remains miles for backward compatibility with the
+	 * existing conversion map consumed by {@see distance()}.
+	 *
 	 * @param \Geo\Geocoder\GeoCoordinate|array<string, mixed> $pointX
 	 * @param \Geo\Geocoder\GeoCoordinate|array<string, mixed> $pointY
-	 * @return float
+	 * @return float Distance in miles
 	 */
 	public static function calculateDistance($pointX, $pointY) {
 		if ($pointX instanceof GeoCoordinate) {

--- a/src/Geocoder/Calculator.php
+++ b/src/Geocoder/Calculator.php
@@ -153,11 +153,35 @@ class Calculator {
 			$pointY = $pointY->toArray(true);
 		}
 
-		$res = 69.09 * rad2deg(acos(sin(deg2rad($pointX['lat'])) * sin(deg2rad($pointY['lat']))
-			+ cos(deg2rad($pointX['lat'])) * cos(deg2rad($pointY['lat'])) * cos(deg2rad($pointX['lng']
-			- $pointY['lng']))));
+		$latX = deg2rad((float)$pointX['lat']);
+		$latY = deg2rad((float)$pointY['lat']);
+		$deltaLat = $latY - $latX;
+		$deltaLng = deg2rad(static::normalizeLongitudeDelta((float)$pointY['lng'] - (float)$pointX['lng']));
+
+		$sinLat = sin($deltaLat / 2);
+		$sinLng = sin($deltaLng / 2);
+		$haversine = $sinLat * $sinLat
+			+ cos($latX) * cos($latY) * $sinLng * $sinLng;
+
+		// Keep the return unit in miles for BC with the existing converter map.
+		$res = 3958.7613 * 2 * asin(min(1.0, sqrt($haversine)));
 
 		return $res;
+	}
+
+	/**
+	 * Normalize a longitude delta to the shortest path around the globe.
+	 *
+	 * @param float $deltaLongitude
+	 * @return float
+	 */
+	protected static function normalizeLongitudeDelta(float $deltaLongitude): float {
+		$deltaLongitude = fmod($deltaLongitude + 180.0, 360.0);
+		if ($deltaLongitude < 0) {
+			$deltaLongitude += 360.0;
+		}
+
+		return $deltaLongitude - 180.0;
 	}
 
 	/**

--- a/src/Model/Behavior/GeocoderBehavior.php
+++ b/src/Model/Behavior/GeocoderBehavior.php
@@ -431,11 +431,14 @@ class GeocoderBehavior extends Behavior {
 
 		$lat = $options[static::OPTION_LAT];
 		$lng = $options[static::OPTION_LNG];
+		$pointWkt = $this->buildPointWkt($lng, $lat);
+		$pointPlaceholder = $query->getValueBinder()->placeholder('geoPoint');
+		$query->bind($pointPlaceholder, $pointWkt, 'string');
 
 		// Add distance calculation as a virtual field
 		$query->select([
 			'distance' => new QueryExpression(
-				"ST_Distance_Sphere(coordinates, ST_GeomFromText('POINT($lng $lat)')) / 1000",
+				"ST_Distance_Sphere(coordinates, ST_GeomFromText($pointPlaceholder)) / 1000",
 			),
 		]);
 
@@ -454,17 +457,18 @@ class GeocoderBehavior extends Behavior {
 			$maxLng = $lng + $lngDelta;
 
 			// Bounding box filter using ST_Within (CAN use spatial index)
-			$envelope = "ST_GeomFromText('POLYGON(($minLng $minLat, $maxLng $minLat, $maxLng $maxLat, $minLng $maxLat, $minLng $minLat))')";
-			$query->where(function (QueryExpression $exp) use ($envelope) {
+			$envelopePlaceholder = $query->getValueBinder()->placeholder('geoEnvelope');
+			$query->bind($envelopePlaceholder, $this->buildPolygonWkt($minLng, $minLat, $maxLng, $maxLat), 'string');
+			$query->where(function (QueryExpression $exp) use ($envelopePlaceholder) {
 				return $exp->add(
-					new QueryExpression("ST_Within(coordinates, $envelope)"),
+					new QueryExpression("ST_Within(coordinates, ST_GeomFromText($envelopePlaceholder))"),
 				);
 			});
 
 			// Precise distance filter (on already-filtered result set)
-			$query->where(function (QueryExpression $exp) use ($lat, $lng, $distance) {
+			$query->where(function (QueryExpression $exp) use ($pointPlaceholder, $distance) {
 				return $exp->lte(
-					new QueryExpression("ST_Distance_Sphere(coordinates, ST_GeomFromText('POINT($lng $lat)')) / 1000"),
+					new QueryExpression("ST_Distance_Sphere(coordinates, ST_GeomFromText($pointPlaceholder)) / 1000"),
 					$distance,
 				);
 			});
@@ -647,6 +651,10 @@ class GeocoderBehavior extends Behavior {
 				$data = $result->data;
 				// Reconstruct Location from JSON data (array)
 				if (is_array($data) && $data) {
+					if (!empty($data['_miss'])) {
+						return null;
+					}
+
 					return CachedLocation::createFromArray($data);
 				}
 				// Invalid or empty cached data - delete and re-geocode
@@ -685,6 +693,8 @@ class GeocoderBehavior extends Behavior {
 				}
 				// Store as JSON array instead of serialized object to avoid __PHP_Incomplete_Class issues
 				$addressEntity->data = $result->toArray();
+			} else {
+				$addressEntity->data = ['_miss' => true];
 			}
 
 			if (!$GeocodedAddresses->save($addressEntity, ['atomic' => false])) {
@@ -707,6 +717,49 @@ class GeocoderBehavior extends Behavior {
 		}
 
 		return $this->_Calculator->convert(6371.04, Calculator::UNIT_KM, $unit);
+	}
+
+	/**
+	 * @param float $lng
+	 * @param float $lat
+	 * @return string
+	 */
+	protected function buildPointWkt(float $lng, float $lat): string {
+		return 'POINT(' . $this->formatCoordinate($lng) . ' ' . $this->formatCoordinate($lat) . ')';
+	}
+
+	/**
+	 * @param float $minLng
+	 * @param float $minLat
+	 * @param float $maxLng
+	 * @param float $maxLat
+	 * @return string
+	 */
+	protected function buildPolygonWkt(float $minLng, float $minLat, float $maxLng, float $maxLat): string {
+		$points = [
+			[$minLng, $minLat],
+			[$maxLng, $minLat],
+			[$maxLng, $maxLat],
+			[$minLng, $maxLat],
+			[$minLng, $minLat],
+		];
+		$coordinates = array_map(function (array $point): string {
+			return $this->formatCoordinate($point[0]) . ' ' . $this->formatCoordinate($point[1]);
+		}, $points);
+
+		return 'POLYGON((' . implode(', ', $coordinates) . '))';
+	}
+
+	/**
+	 * @param float $value
+	 * @return string
+	 */
+	protected function formatCoordinate(float $value): string {
+		if ($value === 0.0) {
+			return '0';
+		}
+
+		return rtrim(rtrim(sprintf('%.12F', $value), '0'), '.');
 	}
 
 	/**

--- a/tests/TestCase/Geocoder/CalculatorTest.php
+++ b/tests/TestCase/Geocoder/CalculatorTest.php
@@ -39,7 +39,7 @@ class CalculatorTest extends TestCase {
 		$coords = [
 			['name' => 'MUC/Pforzheim (269km road, 2:33h)', 'x' => ['lat' => 48.1391, 'lng' => 11.5802], 'y' => ['lat' => 48.8934, 'lng' => 8.70492], 'd' => 228],
 			['name' => 'MUC/London (1142km road, 11:20h)', 'x' => ['lat' => 48.1391, 'lng' => 11.5802], 'y' => ['lat' => 51.508, 'lng' => -0.124688], 'd' => 919],
-			['name' => 'MUC/NewYork (--- road, ---h)', 'x' => ['lat' => 48.1391, 'lng' => 11.5802], 'y' => ['lat' => 40.700943, 'lng' => -73.853531], 'd' => 6479],
+			['name' => 'MUC/NewYork (--- road, ---h)', 'x' => ['lat' => 48.1391, 'lng' => 11.5802], 'y' => ['lat' => 40.700943, 'lng' => -73.853531], 'd' => 6480],
 		];
 
 		foreach ($coords as $coord) {
@@ -52,7 +52,7 @@ class CalculatorTest extends TestCase {
 
 		// String directly
 		$is = $this->Calculator->distance($coords[0]['x'], $coords[0]['y'], 'F');
-		$this->assertEquals(747236, $is);
+		$this->assertEquals(747273, $is);
 	}
 
 	/**
@@ -147,6 +147,31 @@ class CalculatorTest extends TestCase {
 
 		$this->assertGreaterThan(140, $result);
 		$this->assertLessThan(150, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCalculateDistanceShortRange(): void {
+		$pointX = ['lat' => 52.52, 'lng' => 13.405];
+		$pointY = ['lat' => 52.5201, 'lng' => 13.405];
+
+		$result = Calculator::calculateDistance($pointX, $pointY);
+
+		$this->assertEqualsWithDelta(0.0069, $result, 0.0005);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCalculateDistanceAcrossAntimeridian(): void {
+		$pointX = ['lat' => 0.0, 'lng' => 179.9];
+		$pointY = ['lat' => 0.0, 'lng' => -179.9];
+
+		$result = Calculator::calculateDistance($pointX, $pointY);
+
+		$this->assertGreaterThan(13, $result);
+		$this->assertLessThan(14, $result);
 	}
 
 	/**

--- a/tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php
@@ -14,8 +14,11 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Geo\Geocoder\Calculator;
 use Geo\Geocoder\Geocoder;
+use Geocoder\Model\AddressCollection;
 use Geocoder\Model\Coordinates;
 use InvalidArgumentException;
+use ReflectionMethod;
+use ReflectionProperty;
 use TestApp\Controller\TestController;
 
 class GeocoderBehaviorTest extends TestCase {
@@ -25,6 +28,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	protected array $fixtures = [
 		'plugin.Geo.Addresses',
+		'plugin.Geo.GeocodedAddresses',
 	];
 
 	/**
@@ -175,6 +179,25 @@ class GeocoderBehaviorTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testFindSpatialBindsGeometryParameters(): void {
+		/** @var \Geo\Model\Behavior\GeocoderBehavior $behavior */
+		$behavior = $this->Addresses->getBehavior('Geocoder');
+
+		$query = $this->Addresses->find();
+		$query = $behavior->findSpatial($query, 13.3, 19.2, null, 3000);
+		$sql = $query->sql();
+		$bindings = $query->getValueBinder()->bindings();
+
+		$this->assertStringContainsString('ST_GeomFromText(:geoPoint', $sql);
+		$this->assertStringContainsString('ST_GeomFromText(:geoEnvelope', $sql);
+		$this->assertCount(3, $bindings);
+		$this->assertSame('POINT(19.2 13.3)', $this->firstBindingValueMatching($bindings, 'POINT('));
+		$this->assertStringStartsWith('POLYGON((', (string)$this->firstBindingValueMatching($bindings, 'POLYGON(('));
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testPagination() {
 		$driver = $this->db->getDriver();
 		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
@@ -269,6 +292,36 @@ class GeocoderBehaviorTest extends TestCase {
 		$this->assertTrue(!empty($res));
 		$this->assertSame('Bibersfeld', $res->geocoder_result['address_data']);
 	}
+
+	/**
+	 * @return void
+	 */
+	public function testExecuteCachesMisses(): void {
+		$this->Addresses->removeBehavior('Geocoder');
+		$this->Addresses->addBehavior('Geo.Geocoder', ['cache' => true]);
+		/** @var \Geo\Model\Behavior\GeocoderBehavior $behavior */
+		$behavior = $this->Addresses->getBehavior('Geocoder');
+
+		$geocoder = $this->createMock(Geocoder::class);
+		$geocoder->expects($this->once())
+			->method('geocode')
+			->with('Missing Place')
+			->willReturn(new AddressCollection([]));
+		$behaviorReflection = new ReflectionMethod($behavior, '_execute');
+		$behaviorReflection->setAccessible(true);
+
+		$property = new ReflectionProperty($behavior, '_Geocoder');
+		$property->setAccessible(true);
+		$property->setValue($behavior, $geocoder);
+
+		$this->assertNull($behaviorReflection->invoke($behavior, 'Missing Place'));
+		$this->assertNull($behaviorReflection->invoke($behavior, 'Missing Place'));
+
+		/** @var \Geo\Model\Table\GeocodedAddressesTable $GeocodedAddresses */
+		$GeocodedAddresses = TableRegistry::getTableLocator()->get('Geo.GeocodedAddresses');
+		$record = $GeocodedAddresses->find()->where(['address' => 'Missing Place'])->firstOrFail();
+		$this->assertSame(['_miss' => true], $record->data);
+	}
 	/**
 	 * @return void
 	 */
@@ -334,6 +387,21 @@ class GeocoderBehaviorTest extends TestCase {
 		$res = $this->Addresses->save($entity);
 
 		$this->assertTrue(!empty($res));
+	}
+
+	/**
+	 * @param array<string, array<string, mixed>> $bindings
+	 * @param string $prefix
+	 * @return mixed
+	 */
+	protected function firstBindingValueMatching(array $bindings, string $prefix) {
+		foreach ($bindings as $binding) {
+			if (str_starts_with((string)$binding['value'], $prefix)) {
+				return $binding['value'];
+			}
+		}
+
+		$this->fail(sprintf('No binding matched prefix `%s`.', $prefix));
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
+++ b/tests/TestCase/Model/Table/SpatialAddressesTableTest.php
@@ -138,11 +138,29 @@ class SpatialAddressesTableTest extends TestCase {
 		]);
 
 		$sql = $query->sql();
+		$bindings = $query->getValueBinder()->bindings();
 
 		// Verify the query uses ST_Within for bounding box filtering (enables spatial index usage)
 		$this->assertStringContainsString('ST_Within', $sql, 'Query should use ST_Within for spatial index support');
-		$this->assertStringContainsString('POLYGON', $sql, 'Query should use POLYGON for bounding box');
+		$this->assertStringContainsString('ST_GeomFromText(:geoEnvelope', $sql, 'Query should bind the bounding box geometry');
+		$this->assertNotEmpty($bindings);
+		$this->assertTrue($this->containsBindingWithPrefix($bindings, 'POLYGON(('), 'Query should bind a POLYGON WKT for the bounding box');
 		$this->assertStringContainsString('ST_Distance_Sphere', $sql, 'Query should use ST_Distance_Sphere for precise distance');
+	}
+
+	/**
+	 * @param array<string, array<string, mixed>> $bindings
+	 * @param string $prefix
+	 * @return bool
+	 */
+	protected function containsBindingWithPrefix(array $bindings, string $prefix): bool {
+		foreach ($bindings as $binding) {
+			if (str_starts_with((string)$binding['value'], $prefix)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
## Summary
- switch `Calculator::calculateDistance()` to a haversine implementation with dateline-safe longitude deltas
- bind the `findSpatial()` WKT geometries as query parameters instead of interpolating them into SQL
- persist cache misses with a sentinel payload so failed lookups do not re-hit providers forever

## Tests
- `vendor/bin/phpunit tests/TestCase/Geocoder/CalculatorTest.php tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyze`
- `vendor/bin/phpcs`
