### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Controller/Admin/GeoController.php
+++ b/src/Controller/Admin/GeoController.php
@@ -51,7 +51,7 @@ class GeoController extends AppController {
 			}
 		}
 
-		$this->set(['entity' => $entity]);
+		$this->set(compact('entity'));
 	}
 
 }

--- a/src/Controller/Admin/GeoController.php
+++ b/src/Controller/Admin/GeoController.php
@@ -51,7 +51,7 @@ class GeoController extends AppController {
 			}
 		}
 
-		$this->set(compact('entity'));
+		$this->set(['entity' => $entity]);
 	}
 
 }

--- a/src/Controller/Admin/GeocodedAddressesController.php
+++ b/src/Controller/Admin/GeocodedAddressesController.php
@@ -21,7 +21,7 @@ class GeocodedAddressesController extends AppController {
 	public function index() {
 		$geocodedAddresses = $this->paginate($this->GeocodedAddresses);
 
-		$this->set(['geocodedAddresses' => $geocodedAddresses]);
+		$this->set(compact('geocodedAddresses'));
 	}
 
 	/**
@@ -81,7 +81,7 @@ class GeocodedAddressesController extends AppController {
 			}
 			$this->Flash->error(__d('geo', 'The geocoded address could not be saved. Please, try again.'));
 		}
-		$this->set(['geocodedAddress' => $geocodedAddress]);
+		$this->set(compact('geocodedAddress'));
 	}
 
 	/**

--- a/src/Controller/Admin/GeocodedAddressesController.php
+++ b/src/Controller/Admin/GeocodedAddressesController.php
@@ -21,7 +21,7 @@ class GeocodedAddressesController extends AppController {
 	public function index() {
 		$geocodedAddresses = $this->paginate($this->GeocodedAddresses);
 
-		$this->set(compact('geocodedAddresses'));
+		$this->set(['geocodedAddresses' => $geocodedAddresses]);
 	}
 
 	/**
@@ -81,7 +81,7 @@ class GeocodedAddressesController extends AppController {
 			}
 			$this->Flash->error(__d('geo', 'The geocoded address could not be saved. Please, try again.'));
 		}
-		$this->set(compact('geocodedAddress'));
+		$this->set(['geocodedAddress' => $geocodedAddress]);
 	}
 
 	/**

--- a/src/Geocoder/CachedLocation.php
+++ b/src/Geocoder/CachedLocation.php
@@ -205,13 +205,13 @@ class CachedLocation implements Location {
 
 		$country = null;
 		$countryCode = null;
-		if ($this->country !== null) {
+		if ($this->country instanceof \Geocoder\Model\Country) {
 			$country = $this->country->getName();
 			$countryCode = $this->country->getCode();
 		}
 
 		$bounds = null;
-		if ($this->bounds !== null) {
+		if ($this->bounds instanceof \Geocoder\Model\Bounds) {
 			$bounds = [
 				'south' => $this->bounds->getSouth(),
 				'west' => $this->bounds->getWest(),

--- a/src/Geocoder/CachedLocation.php
+++ b/src/Geocoder/CachedLocation.php
@@ -205,13 +205,13 @@ class CachedLocation implements Location {
 
 		$country = null;
 		$countryCode = null;
-		if ($this->country instanceof \Geocoder\Model\Country) {
+		if ($this->country instanceof Country) {
 			$country = $this->country->getName();
 			$countryCode = $this->country->getCode();
 		}
 
 		$bounds = null;
-		if ($this->bounds instanceof \Geocoder\Model\Bounds) {
+		if ($this->bounds instanceof Bounds) {
 			$bounds = [
 				'south' => $this->bounds->getSouth(),
 				'west' => $this->bounds->getWest(),

--- a/src/Geocoder/Calculator.php
+++ b/src/Geocoder/Calculator.php
@@ -127,12 +127,12 @@ class Calculator {
 			$unit = array_keys($this->_units);
 			$unit = $unit[0];
 		}
-		$unit = strtoupper($unit);
+		$unit = strtoupper((string) $unit);
 		if (!isset($this->_units[$unit])) {
 			throw new CalculatorException(sprintf('Invalid Unit: %s', $unit));
 		}
 
-		$res = $this->calculateDistance($pointX, $pointY);
+		$res = static::calculateDistance($pointX, $pointY);
 		if (isset($this->_units[$unit])) {
 			$res *= $this->_units[$unit];
 		}
@@ -204,7 +204,7 @@ class Calculator {
 			return $coordinate;
 		}
 
-		$scrambleVal = 0.000001 * mt_rand(10, 200) * pow(2, $level) * (mt_rand(0, 1) === 0 ? 1 : -1);
+		$scrambleVal = 0.000001 * mt_rand(10, 200) * 2 ** $level * (mt_rand(0, 1) === 0 ? 1 : -1);
 
 		return $coordinate + $scrambleVal;
 	}

--- a/src/Geocoder/Calculator.php
+++ b/src/Geocoder/Calculator.php
@@ -127,7 +127,7 @@ class Calculator {
 			$unit = array_keys($this->_units);
 			$unit = $unit[0];
 		}
-		$unit = strtoupper((string) $unit);
+		$unit = strtoupper((string)$unit);
 		if (!isset($this->_units[$unit])) {
 			throw new CalculatorException(sprintf('Invalid Unit: %s', $unit));
 		}

--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -232,7 +232,7 @@ class Geocoder {
 	 * @return array<string, string>
 	 */
 	public function accuracyTypes() {
-		$array = [
+		return [
 			static::TYPE_COUNTRY => __d('geo', 'Country'),
 			static::TYPE_AAL1 => __d('geo', 'Province'),
 			static::TYPE_AAL3 => __d('geo', 'Sub Province'),
@@ -244,8 +244,6 @@ class Geocoder {
 			static::TYPE_ADDRESS => __d('geo', 'Street Address'),
 			static::TYPE_NUMBER => __d('geo', 'Street Number'),
 		];
-
-		return $array;
 	}
 
 	/**
@@ -319,7 +317,7 @@ class Geocoder {
 	 * @return \Geocoder\Model\AddressCollection
 	 */
 	protected function executeGeocode(string $address): AddressCollection {
-		if ($this->providerInstance !== null) {
+		if ($this->providerInstance instanceof \Geo\Geocoder\Provider\GeocodingProviderInterface) {
 			return $this->providerInstance->geocode($address);
 		}
 
@@ -339,7 +337,7 @@ class Geocoder {
 	 * @return \Geocoder\Model\AddressCollection
 	 */
 	protected function executeReverse(float $lat, float $lng): AddressCollection {
-		if ($this->providerInstance !== null) {
+		if ($this->providerInstance instanceof \Geo\Geocoder\Provider\GeocodingProviderInterface) {
 			return $this->providerInstance->reverse($lat, $lng);
 		}
 

--- a/src/Geocoder/Geocoder.php
+++ b/src/Geocoder/Geocoder.php
@@ -317,7 +317,7 @@ class Geocoder {
 	 * @return \Geocoder\Model\AddressCollection
 	 */
 	protected function executeGeocode(string $address): AddressCollection {
-		if ($this->providerInstance instanceof \Geo\Geocoder\Provider\GeocodingProviderInterface) {
+		if ($this->providerInstance instanceof GeocodingProviderInterface) {
 			return $this->providerInstance->geocode($address);
 		}
 
@@ -337,7 +337,7 @@ class Geocoder {
 	 * @return \Geocoder\Model\AddressCollection
 	 */
 	protected function executeReverse(float $lat, float $lng): AddressCollection {
-		if ($this->providerInstance instanceof \Geo\Geocoder\Provider\GeocodingProviderInterface) {
+		if ($this->providerInstance instanceof GeocodingProviderInterface) {
 			return $this->providerInstance->reverse($lat, $lng);
 		}
 

--- a/src/Geocoder/Provider/AbstractGeocodingProvider.php
+++ b/src/Geocoder/Provider/AbstractGeocodingProvider.php
@@ -89,7 +89,7 @@ abstract class AbstractGeocodingProvider implements GeocodingProviderInterface {
 	 * @return \Cake\Http\Client
 	 */
 	protected function getHttpClient(): Client {
-		if (!$this->httpClient instanceof \Cake\Http\Client) {
+		if (!$this->httpClient instanceof Client) {
 			$this->httpClient = new Client();
 		}
 
@@ -102,7 +102,7 @@ abstract class AbstractGeocodingProvider implements GeocodingProviderInterface {
 	 * @return \Geocoder\StatefulGeocoder
 	 */
 	protected function getGeocoder(): StatefulGeocoder {
-		if (!$this->geocoder instanceof \Geocoder\StatefulGeocoder) {
+		if (!$this->geocoder instanceof StatefulGeocoder) {
 			$provider = $this->buildProvider();
 			$locale = $this->getConfig('locale') ?: 'en';
 			$this->geocoder = new StatefulGeocoder($provider, $locale);

--- a/src/Geocoder/Provider/AbstractGeocodingProvider.php
+++ b/src/Geocoder/Provider/AbstractGeocodingProvider.php
@@ -89,7 +89,7 @@ abstract class AbstractGeocodingProvider implements GeocodingProviderInterface {
 	 * @return \Cake\Http\Client
 	 */
 	protected function getHttpClient(): Client {
-		if ($this->httpClient === null) {
+		if (!$this->httpClient instanceof \Cake\Http\Client) {
 			$this->httpClient = new Client();
 		}
 
@@ -102,7 +102,7 @@ abstract class AbstractGeocodingProvider implements GeocodingProviderInterface {
 	 * @return \Geocoder\StatefulGeocoder
 	 */
 	protected function getGeocoder(): StatefulGeocoder {
-		if ($this->geocoder === null) {
+		if (!$this->geocoder instanceof \Geocoder\StatefulGeocoder) {
 			$provider = $this->buildProvider();
 			$locale = $this->getConfig('locale') ?: 'en';
 			$this->geocoder = new StatefulGeocoder($provider, $locale);

--- a/src/Geocoder/Provider/GeoapifyProvider.php
+++ b/src/Geocoder/Provider/GeoapifyProvider.php
@@ -114,7 +114,7 @@ class GeoapifyProvider extends AbstractGeocodingProvider {
 		$addresses = [];
 		foreach ($data['features'] as $feature) {
 			$address = $this->parseFeature($feature);
-			if ($address instanceof \Geocoder\Model\Address) {
+			if ($address instanceof Address) {
 				$addresses[] = $address;
 			}
 		}
@@ -175,7 +175,7 @@ class GeoapifyProvider extends AbstractGeocodingProvider {
 		}
 
 		if (!empty($props['country_code'])) {
-			$builder->setCountryCode(strtoupper((string) $props['country_code']));
+			$builder->setCountryCode(strtoupper((string)$props['country_code']));
 		}
 
 		return $builder->build();

--- a/src/Geocoder/Provider/GeoapifyProvider.php
+++ b/src/Geocoder/Provider/GeoapifyProvider.php
@@ -114,7 +114,7 @@ class GeoapifyProvider extends AbstractGeocodingProvider {
 		$addresses = [];
 		foreach ($data['features'] as $feature) {
 			$address = $this->parseFeature($feature);
-			if ($address !== null) {
+			if ($address instanceof \Geocoder\Model\Address) {
 				$addresses[] = $address;
 			}
 		}
@@ -175,7 +175,7 @@ class GeoapifyProvider extends AbstractGeocodingProvider {
 		}
 
 		if (!empty($props['country_code'])) {
-			$builder->setCountryCode(strtoupper($props['country_code']));
+			$builder->setCountryCode(strtoupper((string) $props['country_code']));
 		}
 
 		return $builder->build();

--- a/src/Geometry/Polygon.php
+++ b/src/Geometry/Polygon.php
@@ -7,13 +7,12 @@ class Polygon implements GeoJsonInterface {
 	/**
 	 * @var array<int, array<int, array{0: float, 1: float}>>
 	 */
-	protected array $rings;
+	protected array $rings = [];
 
 	/**
 	 * @param array<int, array<int, array{0: float|int, 1: float|int}>> $rings
 	 */
 	public function __construct(array $rings) {
-		$this->rings = [];
 		foreach ($rings as $ring) {
 			$this->rings[] = $this->normalizeRing($ring);
 		}

--- a/src/Model/Behavior/GeocoderBehavior.php
+++ b/src/Model/Behavior/GeocoderBehavior.php
@@ -548,13 +548,13 @@ class GeocoderBehavior extends Behavior {
 		}
 
 		// Validate field and table names to prevent SQL injection
-		if (!preg_match('/^\w+$/', (string)$tableName)) {
+		if (!is_string($tableName) || !preg_match('/^\w+$/', $tableName)) {
 			throw new InvalidArgumentException('Invalid table name');
 		}
-		if (!preg_match('/^\w+$/', (string)$fieldLat)) {
+		if (!is_string($fieldLat) || !preg_match('/^\w+$/', $fieldLat)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
-		if (!preg_match('/^\w+$/', (string)$fieldLng)) {
+		if (!is_string($fieldLng) || !preg_match('/^\w+$/', $fieldLng)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
 

--- a/src/Model/Behavior/GeocoderBehavior.php
+++ b/src/Model/Behavior/GeocoderBehavior.php
@@ -175,9 +175,9 @@ class GeocoderBehavior extends Behavior {
 	 */
 	public function afterMarshal(EventInterface $event, EntityInterface $entity): void {
 		if ($this->_config['on'] === 'afterMarshal' && !$this->geocode($entity)) {
-            $event->setResult(false);
-            $event->stopPropagation();
-        }
+			$event->setResult(false);
+			$event->stopPropagation();
+		}
 	}
 
 	/**
@@ -188,9 +188,9 @@ class GeocoderBehavior extends Behavior {
 	 */
 	public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
 		if ($this->_config['on'] === 'beforeRules' && !$this->geocode($entity)) {
-            $event->setResult(false);
-            $event->stopPropagation();
-        }
+			$event->setResult(false);
+			$event->stopPropagation();
+		}
 	}
 
 	/**
@@ -201,9 +201,9 @@ class GeocoderBehavior extends Behavior {
 	 */
 	public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
 		if ($this->_config['on'] === 'beforeSave' && !$this->geocode($entity)) {
-            $event->setResult(false);
-            $event->stopPropagation();
-        }
+			$event->setResult(false);
+			$event->stopPropagation();
+		}
 	}
 
 	/**
@@ -548,13 +548,13 @@ class GeocoderBehavior extends Behavior {
 		}
 
 		// Validate field and table names to prevent SQL injection
-		if (!preg_match('/^\w+$/', (string) $tableName)) {
+		if (!preg_match('/^\w+$/', (string)$tableName)) {
 			throw new InvalidArgumentException('Invalid table name');
 		}
-		if (!preg_match('/^\w+$/', (string) $fieldLat)) {
+		if (!preg_match('/^\w+$/', (string)$fieldLat)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
-		if (!preg_match('/^\w+$/', (string) $fieldLng)) {
+		if (!preg_match('/^\w+$/', (string)$fieldLng)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
 
@@ -654,7 +654,7 @@ class GeocoderBehavior extends Behavior {
 
 		try {
 			$addresses = $this->_Geocoder->geocode($address);
-		} catch (InconclusiveException|NotAccurateEnoughException) {
+		} catch (InconclusiveException | NotAccurateEnoughException) {
 			$addresses = null;
 		}
 		$result = null;

--- a/src/Model/Behavior/GeocoderBehavior.php
+++ b/src/Model/Behavior/GeocoderBehavior.php
@@ -174,12 +174,10 @@ class GeocoderBehavior extends Behavior {
 	 * @return void
 	 */
 	public function afterMarshal(EventInterface $event, EntityInterface $entity): void {
-		if ($this->_config['on'] === 'afterMarshal') {
-			if (!$this->geocode($entity)) {
-				$event->setResult(false);
-				$event->stopPropagation();
-			}
-		}
+		if ($this->_config['on'] === 'afterMarshal' && !$this->geocode($entity)) {
+            $event->setResult(false);
+            $event->stopPropagation();
+        }
 	}
 
 	/**
@@ -189,12 +187,10 @@ class GeocoderBehavior extends Behavior {
 	 * @return void
 	 */
 	public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		if ($this->_config['on'] === 'beforeRules') {
-			if (!$this->geocode($entity)) {
-				$event->setResult(false);
-				$event->stopPropagation();
-			}
-		}
+		if ($this->_config['on'] === 'beforeRules' && !$this->geocode($entity)) {
+            $event->setResult(false);
+            $event->stopPropagation();
+        }
 	}
 
 	/**
@@ -204,12 +200,10 @@ class GeocoderBehavior extends Behavior {
 	 * @return void
 	 */
 	public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		if ($this->_config['on'] === 'beforeSave') {
-			if (!$this->geocode($entity)) {
-				$event->setResult(false);
-				$event->stopPropagation();
-			}
-		}
+		if ($this->_config['on'] === 'beforeSave' && !$this->geocode($entity)) {
+            $event->setResult(false);
+            $event->stopPropagation();
+        }
 	}
 
 	/**
@@ -236,11 +230,7 @@ class GeocoderBehavior extends Behavior {
 		$dirty = false;
 		foreach ($addressFields as $field) {
 			$isClosure = $field instanceof Closure;
-			if ($isClosure) {
-				$fieldData = $field($entity);
-			} else {
-				$fieldData = $entity->get($field);
-			}
+			$fieldData = $isClosure ? $field($entity) : $entity->get($field);
 			if ($fieldData) {
 				$addressData[] = $fieldData;
 			}
@@ -558,13 +548,13 @@ class GeocoderBehavior extends Behavior {
 		}
 
 		// Validate field and table names to prevent SQL injection
-		if (!preg_match('/^[a-zA-Z0-9_]+$/', $tableName)) {
+		if (!preg_match('/^\w+$/', (string) $tableName)) {
 			throw new InvalidArgumentException('Invalid table name');
 		}
-		if (!preg_match('/^[a-zA-Z0-9_]+$/', $fieldLat)) {
+		if (!preg_match('/^\w+$/', (string) $fieldLat)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
-		if (!preg_match('/^[a-zA-Z0-9_]+$/', $fieldLng)) {
+		if (!preg_match('/^\w+$/', (string) $fieldLng)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
 
@@ -572,10 +562,10 @@ class GeocoderBehavior extends Behavior {
 			$tableName . '.' . $fieldLat . ' <> 0',
 			$tableName . '.' . $fieldLng . ' <> 0',
 		];
-		$fieldName = !empty($fieldName) ? $fieldName : 'distance';
+		$fieldName = empty($fieldName) ? 'distance' : $fieldName;
 
 		// Validate distance field name
-		if (!preg_match('/^[a-zA-Z0-9_]+$/', $fieldName)) {
+		if (!preg_match('/^\w+$/', $fieldName)) {
 			throw new InvalidArgumentException('Invalid field name');
 		}
 
@@ -599,7 +589,7 @@ class GeocoderBehavior extends Behavior {
 		if ($tableName === null) {
 			$tableName = $this->_table->getAlias();
 		}
-		$fieldName = (!empty($fieldName) ? $fieldName : 'distance');
+		$fieldName = (empty($fieldName) ? 'distance' : $fieldName);
 
 		return [$tableName . '.' . $fieldName => $this->distanceExpr($lat, $lng, null, null, $tableName)];
 	}
@@ -664,9 +654,7 @@ class GeocoderBehavior extends Behavior {
 
 		try {
 			$addresses = $this->_Geocoder->geocode($address);
-		} catch (InconclusiveException $e) {
-			$addresses = null;
-		} catch (NotAccurateEnoughException $e) {
+		} catch (InconclusiveException|NotAccurateEnoughException) {
 			$addresses = null;
 		}
 		$result = null;
@@ -712,7 +700,7 @@ class GeocoderBehavior extends Behavior {
 	 * @return float Value
 	 */
 	protected function _calculationValue($unit) {
-		if (!isset($this->_Calculator)) {
+		if ($this->_Calculator === null) {
 			$this->_Calculator = new Calculator();
 		}
 
@@ -778,7 +766,7 @@ class GeocoderBehavior extends Behavior {
 				$entity->setError($field, $errorMessage);
 			}
 
-			$message = !empty($errorMessage[$field]) ? $errorMessage[$field] : null;
+			$message = empty($errorMessage[$field]) ? null : $errorMessage[$field];
 			if (!$message) {
 				continue;
 			}

--- a/src/Model/Behavior/GeocoderBehavior.php
+++ b/src/Model/Behavior/GeocoderBehavior.php
@@ -548,7 +548,7 @@ class GeocoderBehavior extends Behavior {
 		}
 
 		// Validate field and table names to prevent SQL injection
-		if (!is_string($tableName) || !preg_match('/^\w+$/', $tableName)) {
+		if (!preg_match('/^\w+$/', $tableName)) {
 			throw new InvalidArgumentException('Invalid table name');
 		}
 		if (!is_string($fieldLat) || !preg_match('/^\w+$/', $fieldLat)) {

--- a/src/Model/Table/GeocodedAddressesTable.php
+++ b/src/Model/Table/GeocodedAddressesTable.php
@@ -157,7 +157,7 @@ class GeocodedAddressesTable extends Table {
 		$this->_Geocoder = new Geocoder();
 		try {
 			$addresses = $this->_Geocoder->geocode($address);
-		} catch (InconclusiveException|NotAccurateEnoughException) {
+		} catch (InconclusiveException | NotAccurateEnoughException) {
 			return null;
 		}
 

--- a/src/Model/Table/GeocodedAddressesTable.php
+++ b/src/Model/Table/GeocodedAddressesTable.php
@@ -157,9 +157,7 @@ class GeocodedAddressesTable extends Table {
 		$this->_Geocoder = new Geocoder();
 		try {
 			$addresses = $this->_Geocoder->geocode($address);
-		} catch (InconclusiveException $e) {
-			return null;
-		} catch (NotAccurateEnoughException $e) {
+		} catch (InconclusiveException|NotAccurateEnoughException) {
 			return null;
 		}
 

--- a/src/StaticMap/Provider/GeoapifyProvider.php
+++ b/src/StaticMap/Provider/GeoapifyProvider.php
@@ -135,7 +135,7 @@ class GeoapifyProvider extends AbstractStaticMapProvider {
 			$parts[] = empty($marker['icon']) ? 'type:material' : 'type:' . $marker['icon'];
 
 			if (!empty($marker['label'])) {
-				$parts[] = 'text:' . urlencode((string) $marker['label']);
+				$parts[] = 'text:' . urlencode((string)$marker['label']);
 			}
 
 			$formatted[] = implode(';', $parts);

--- a/src/StaticMap/Provider/GeoapifyProvider.php
+++ b/src/StaticMap/Provider/GeoapifyProvider.php
@@ -130,20 +130,12 @@ class GeoapifyProvider extends AbstractStaticMapProvider {
 				$parts[] = 'color:%23' . $this->formatColor($marker['color']);
 			}
 
-			if (!empty($marker['size'])) {
-				$parts[] = 'size:' . $marker['size'];
-			} else {
-				$parts[] = 'size:medium';
-			}
+			$parts[] = empty($marker['size']) ? 'size:medium' : 'size:' . $marker['size'];
 
-			if (!empty($marker['icon'])) {
-				$parts[] = 'type:' . $marker['icon'];
-			} else {
-				$parts[] = 'type:material';
-			}
+			$parts[] = empty($marker['icon']) ? 'type:material' : 'type:' . $marker['icon'];
 
 			if (!empty($marker['label'])) {
-				$parts[] = 'text:' . urlencode($marker['label']);
+				$parts[] = 'text:' . urlencode((string) $marker['label']);
 			}
 
 			$formatted[] = implode(';', $parts);

--- a/src/StaticMap/Provider/GoogleProvider.php
+++ b/src/StaticMap/Provider/GoogleProvider.php
@@ -121,16 +121,16 @@ class GoogleProvider extends AbstractStaticMapProvider {
 			}
 
 			if (!empty($marker['label'])) {
-				$style[] = 'label:' . strtoupper(substr((string) $marker['label'], 0, 1));
+				$style[] = 'label:' . strtoupper(substr((string)$marker['label'], 0, 1));
 			}
 
 			if (!empty($marker['size'])) {
 				$sizeMap = ['small' => 'small', 'medium' => 'mid', 'large' => 'small'];
-				$style[] = 'size:' . ($sizeMap[strtolower((string) $marker['size'])] ?? 'mid');
+				$style[] = 'size:' . ($sizeMap[strtolower((string)$marker['size'])] ?? 'mid');
 			}
 
 			if (!empty($marker['icon'])) {
-				$style[] = 'icon:' . urlencode((string) $marker['icon']);
+				$style[] = 'icon:' . urlencode((string)$marker['icon']);
 			}
 
 			$position = $marker['lat'] . ',' . $marker['lng'];

--- a/src/StaticMap/Provider/GoogleProvider.php
+++ b/src/StaticMap/Provider/GoogleProvider.php
@@ -50,7 +50,7 @@ class GoogleProvider extends AbstractStaticMapProvider {
 
 		// Auto-calculate center and zoom if not provided
 		$options = $this->autoCalculateBounds($options, $markers, $paths);
-		$options['zoom'] = $options['zoom'] ?? 12;
+		$options['zoom'] ??= 12;
 
 		$params = [
 			'key' => $config['apiKey'],
@@ -121,16 +121,16 @@ class GoogleProvider extends AbstractStaticMapProvider {
 			}
 
 			if (!empty($marker['label'])) {
-				$style[] = 'label:' . strtoupper(substr($marker['label'], 0, 1));
+				$style[] = 'label:' . strtoupper(substr((string) $marker['label'], 0, 1));
 			}
 
 			if (!empty($marker['size'])) {
 				$sizeMap = ['small' => 'small', 'medium' => 'mid', 'large' => 'small'];
-				$style[] = 'size:' . ($sizeMap[strtolower($marker['size'])] ?? 'mid');
+				$style[] = 'size:' . ($sizeMap[strtolower((string) $marker['size'])] ?? 'mid');
 			}
 
 			if (!empty($marker['icon'])) {
-				$style[] = 'icon:' . urlencode($marker['icon']);
+				$style[] = 'icon:' . urlencode((string) $marker['icon']);
 			}
 
 			$position = $marker['lat'] . ',' . $marker['lng'];

--- a/src/StaticMap/Provider/MapboxProvider.php
+++ b/src/StaticMap/Provider/MapboxProvider.php
@@ -54,7 +54,7 @@ class MapboxProvider extends AbstractStaticMapProvider {
 
 		// Auto-calculate center and zoom if not provided
 		$options = $this->autoCalculateBounds($options, $markers, $paths);
-		$options['zoom'] = $options['zoom'] ?? 12;
+		$options['zoom'] ??= 12;
 
 		$size = $this->parseSize($options['size']);
 		$username = $options['username'];
@@ -86,11 +86,9 @@ class MapboxProvider extends AbstractStaticMapProvider {
 			$sizeStr .= '@2x';
 		}
 
-		$url = static::BASE_URL . '/' . $username . '/' . $style . '/static/'
+		return static::BASE_URL . '/' . $username . '/' . $style . '/static/'
 			. $overlayStr . $center . '/' . $sizeStr
 			. '?access_token=' . $config['apiKey'];
-
-		return $url;
 	}
 
 	/**
@@ -130,13 +128,13 @@ class MapboxProvider extends AbstractStaticMapProvider {
 			$size = 's';
 			if (!empty($marker['size'])) {
 				$sizeMap = ['small' => 's', 'medium' => 'm', 'large' => 'l'];
-				$size = $sizeMap[strtolower($marker['size'])] ?? 's';
+				$size = $sizeMap[strtolower((string) $marker['size'])] ?? 's';
 			}
 
 			$pin = 'pin-' . $size;
 
 			if (!empty($marker['label'])) {
-				$pin .= '-' . strtolower(substr($marker['label'], 0, 1));
+				$pin .= '-' . strtolower(substr((string) $marker['label'], 0, 1));
 			}
 
 			if (!empty($marker['color'])) {

--- a/src/StaticMap/Provider/MapboxProvider.php
+++ b/src/StaticMap/Provider/MapboxProvider.php
@@ -128,13 +128,13 @@ class MapboxProvider extends AbstractStaticMapProvider {
 			$size = 's';
 			if (!empty($marker['size'])) {
 				$sizeMap = ['small' => 's', 'medium' => 'm', 'large' => 'l'];
-				$size = $sizeMap[strtolower((string) $marker['size'])] ?? 's';
+				$size = $sizeMap[strtolower((string)$marker['size'])] ?? 's';
 			}
 
 			$pin = 'pin-' . $size;
 
 			if (!empty($marker['label'])) {
-				$pin .= '-' . strtolower(substr((string) $marker['label'], 0, 1));
+				$pin .= '-' . strtolower(substr((string)$marker['label'], 0, 1));
 			}
 
 			if (!empty($marker['color'])) {

--- a/src/StaticMap/Provider/StadiaProvider.php
+++ b/src/StaticMap/Provider/StadiaProvider.php
@@ -140,7 +140,7 @@ class StadiaProvider extends AbstractStaticMapProvider {
 
 			if (!empty($marker['size'])) {
 				$sizeMap = ['small' => 'sm', 'medium' => 'md', 'large' => 'lg'];
-				$markerStyle .= '-' . ($sizeMap[strtolower((string) $marker['size'])] ?? 'md');
+				$markerStyle .= '-' . ($sizeMap[strtolower((string)$marker['size'])] ?? 'md');
 			}
 
 			$parts[] = $markerStyle;

--- a/src/StaticMap/Provider/StadiaProvider.php
+++ b/src/StaticMap/Provider/StadiaProvider.php
@@ -50,7 +50,7 @@ class StadiaProvider extends AbstractStaticMapProvider {
 
 		// Auto-calculate center and zoom if not provided
 		$options = $this->autoCalculateBounds($options, $markers, $paths);
-		$options['zoom'] = $options['zoom'] ?? 12;
+		$options['zoom'] ??= 12;
 
 		$size = $this->parseSize($options['size']);
 		$style = $options['style'];
@@ -140,7 +140,7 @@ class StadiaProvider extends AbstractStaticMapProvider {
 
 			if (!empty($marker['size'])) {
 				$sizeMap = ['small' => 'sm', 'medium' => 'md', 'large' => 'lg'];
-				$markerStyle .= '-' . ($sizeMap[strtolower($marker['size'])] ?? 'md');
+				$markerStyle .= '-' . ($sizeMap[strtolower((string) $marker['size'])] ?? 'md');
 			}
 
 			$parts[] = $markerStyle;

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -326,10 +326,8 @@ class GoogleMapHelper extends Helper {
 		if (isset($config['staticLng'])) {
 			$config['staticMap']['lng'] = $config['staticLng'];
 		}
-		if (isset($config['localImages'])) {
-			if ($config['localImages'] === true) {
-				$config['localImages'] = Router::url('/img/google_map/', true);
-			}
+		if (isset($config['localImages']) && $config['localImages'] === true) {
+			$config['localImages'] = Router::url('/img/google_map/', true);
 		}
 
 		// BC
@@ -389,9 +387,8 @@ class GoogleMapHelper extends Helper {
 	 */
 	public function gearsUrl(): string {
 		$this->_gearsIncluded = true;
-		$url = $this->_protocol() . 'code.google.com/apis/gears/gears_init.js';
 
-		return $url;
+		return $this->_protocol() . 'code.google.com/apis/gears/gears_init.js';
 	}
 
 	/**
@@ -533,9 +530,8 @@ class GoogleMapHelper extends Helper {
 		unset($this->_runtimeConfig['div']['height']);
 
 		$defaultText = $this->_runtimeConfig['content'] ?? __d('geo', 'Map cannot be displayed!');
-		$result .= $this->Html->tag('div', $defaultText, $this->_runtimeConfig['div']);
 
-		return $result;
+		return $result . $this->Html->tag('div', $defaultText, $this->_runtimeConfig['div']);
 	}
 
 	/**
@@ -786,20 +782,12 @@ function geocodeAddress(address) {
 		}
 
 		if (!empty($char)) {
-			if ($color === 'red') {
-				$color = '';
-			} else {
-				$color = '_' . $color;
-			}
-			$url = sprintf($this->setIcons['alpha'], $color, $char);
-		} else {
-			if ($color === 'red') {
-				$color = '';
-			} else {
-				$color = '_' . $color;
-			}
-			$url = sprintf($this->setIcons['color'], $color);
-		}
+            $color = $color === 'red' ? '' : '_' . $color;
+            $url = sprintf($this->setIcons['alpha'], $color, $char);
+        } else {
+            $color = $color === 'red' ? '' : '_' . $color;
+            $url = sprintf($this->setIcons['color'], $color);
+        }
 
 		/*
         var iconImage = new google.maps.MarkerImage('images/' + images[0] + ' .png',
@@ -821,13 +809,12 @@ function geocodeAddress(address) {
         */
 
 		$shadow = 'https://www.google.com/mapfiles/shadow50.png';
-		$res = [
+
+		return [
 			'url' => $url,
 			'icon' => $this->icon($url, ['size' => ['width' => 20, 'height' => 34]]),
 			'shadow' => $this->icon($shadow, ['size' => ['width' => 37, 'height' => 34], 'shadow' => ['width' => 10, 'height' => 34]]),
 		];
-
-		return $res;
 	}
 
 	/**
@@ -883,7 +870,7 @@ function geocodeAddress(address) {
 			if (!empty($options['imagePath'])) {
 				$path = realpath($options['imagePath']);
 				$allowedDir = realpath(WWW_ROOT . 'img' . DS);
-				if (!$path || !$allowedDir || strpos($path, $allowedDir) !== 0) {
+				if (!$path || !$allowedDir || !str_starts_with($path, $allowedDir)) {
 					throw new CakeException('Invalid image path');
 				}
 			} else {
@@ -1152,11 +1139,9 @@ function geocodeAddress(address) {
 	 * @return string
 	 */
 	public function script() {
-		$script = '<script>
+		return '<script>
 		' . $this->finalize(true) . '
 </script>';
-
-		return $script;
 	}
 
 	/**
@@ -1323,11 +1308,7 @@ function geocodeAddress(address) {
 			$res[] = 'scaleControlOptions: ' . $this->_controlOptions('scale', $options['scaleOptions']);
 		}
 
-		if (array_key_exists($options['type'], $this->types)) {
-			$type = $this->types[$options['type']];
-		} else {
-			$type = $options['type'];
-		}
+		$type = array_key_exists($options['type'], $this->types) ? $this->types[$options['type']] : $options['type'];
 		$res[] = 'mapTypeId: google.maps.MapTypeId.' . $type;
 
 		return '{' . implode(', ', $res) . '}';
@@ -1384,14 +1365,14 @@ function geocodeAddress(address) {
 	public function mapUrl(array $options = []) {
 		$url = $this->_protocol() . 'maps.google.com/maps?';
 
-		$urlArray = !empty($options['query']) ? $options['query'] : [];
+		$urlArray = empty($options['query']) ? [] : $options['query'];
 		if (!empty($options['from'])) {
 			$urlArray['saddr'] = $options['from'];
 		}
 
 		if (!empty($options['to']) && is_array($options['to'])) {
 			$to = array_shift($options['to']);
-			foreach ($options['to'] as $key => $value) {
+			foreach ($options['to'] as $value) {
 				$to .= '+to:' . $value;
 			}
 			$urlArray['daddr'] = $to;
@@ -1508,16 +1489,16 @@ function geocodeAddress(address) {
 
 		// a position on the map that is supposed to stay visible at all cost
 		if (!empty($mapOptions['visible'])) {
-			$params['visible'] = urlencode($mapOptions['visible']);
+			$params['visible'] = urlencode((string) $mapOptions['visible']);
 		}
 
 		// center and zoom are not necessary if path, visible or markers are given
 		if (!isset($options['center']) || $options['center'] === false) {
 			// dont use it
 		} elseif ($options['center'] === true && $mapOptions['lat'] !== null && $mapOptions['lng'] !== null) {
-			$params['center'] = urlencode((string)$mapOptions['lat'] . ',' . (string)$mapOptions['lng']);
+			$params['center'] = urlencode($mapOptions['lat'] . ',' . $mapOptions['lng']);
 		} elseif (!empty($options['center'])) {
-			$params['center'] = urlencode($options['center']);
+			$params['center'] = urlencode((string) $options['center']);
 		} /*else {
 			// try to read from markers array???
 			if (isset($options['markers']) && count($options['markers']) == 1) {
@@ -1526,25 +1507,23 @@ function geocodeAddress(address) {
 		}*/
 
 		if (!isset($options['zoom']) || $options['zoom'] === false) {
-			// dont use it
-		} else {
-			if ($options['zoom'] === 'auto') {
-				if (!empty($options['markers']) && strpos($options['zoom'], '|') !== false) {
+            // dont use it
+        } elseif ($options['zoom'] === 'auto') {
+            if (!empty($options['markers']) && str_contains($options['zoom'], '|')) {
 					// let google find the best zoom value itself
 				} else {
 					// do something here?
 				}
-			} else {
+        } else {
 				$params['zoom'] = $options['zoom'];
 			}
-		}
 
 		if (array_key_exists($mapOptions['type'], $this->types)) {
 			$params['maptype'] = $this->types[$mapOptions['type']];
 		} else {
 			$params['maptype'] = $mapOptions['type'];
 		}
-		$params['maptype'] = strtolower($params['maptype']);
+		$params['maptype'] = strtolower((string) $params['maptype']);
 
 		// old: {latitude},{longitude},{color}{alpha-character}
 		// new: @see staticMarkers()
@@ -1620,9 +1599,9 @@ function geocodeAddress(address) {
 
 			$path = [];
 			foreach ($options as $key => $value) {
-				$path[] = $key . ':' . urlencode($value);
+				$path[] = $key . ':' . urlencode((string) $value);
 			}
-			foreach ($markers as $key => $pos) {
+			foreach ($markers as $pos) {
 				if (is_array($pos)) {
 					// lat/lng?
 					$pos = $pos['lat'] . ',' . $pos['lng'];
@@ -1681,7 +1660,7 @@ function geocodeAddress(address) {
 			if (!empty($p['lat']) && !empty($p['lng'])) {
 				$p['address'] = $p['lat'] . ',' . $p['lng'];
 			}
-			$p['address'] = urlencode($p['address']);
+			$p['address'] = urlencode((string) $p['address']);
 
 			$values = [];
 
@@ -1692,7 +1671,7 @@ function geocodeAddress(address) {
 			}
 			// label? A-Z0-9
 			if (!empty($p['label'])) {
-				$values[] = 'label:' . strtoupper($p['label']);
+				$values[] = 'label:' . strtoupper((string) $p['label']);
 			}
 			if (!empty($p['size'])) {
 				$values[] = 'size:' . $p['size'];
@@ -1701,7 +1680,7 @@ function geocodeAddress(address) {
 				$values[] = 'shadow:' . $p['shadow'];
 			}
 			if (!empty($p['icon'])) {
-				$values[] = 'icon:' . urlencode($p['icon']);
+				$values[] = 'icon:' . urlencode((string) $p['icon']);
 			}
 			$values[] = $p['address'];
 
@@ -1743,7 +1722,7 @@ function geocodeAddress(address) {
 	 * @return string Color
 	 */
 	protected function _prepColor($color) {
-		if (strpos($color, '#') !== false) {
+		if (str_contains($color, '#')) {
 			return str_replace('#', '0x', $color);
 		}
 		if (is_numeric($color)) {
@@ -1763,9 +1742,8 @@ function geocodeAddress(address) {
 	protected function _arrayToObject($name, $array, $asString = true, $keyAsString = false) {
 		$res = 'var ' . $name . ' = {' . PHP_EOL;
 		$res .= $this->_toObjectParams($array, $asString, $keyAsString);
-		$res .= '};';
 
-		return $res;
+		return $res . '};';
 	}
 
 	/**
@@ -1777,7 +1755,7 @@ function geocodeAddress(address) {
 	protected function _toObjectParams($array, $asString = true, $keyAsString = false) {
 		$pieces = [];
 		foreach ($array as $key => $value) {
-			$e = ($asString && strpos($value, 'new ') !== 0 ? '"' : '');
+			$e = ($asString && !str_starts_with((string) $value, 'new ') ? '"' : '');
 			$ke = ($keyAsString ? '"' : '');
 			$pieces[] = $ke . $key . $ke . ': ' . $e . $value . $e;
 		}

--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -782,12 +782,12 @@ function geocodeAddress(address) {
 		}
 
 		if (!empty($char)) {
-            $color = $color === 'red' ? '' : '_' . $color;
-            $url = sprintf($this->setIcons['alpha'], $color, $char);
-        } else {
-            $color = $color === 'red' ? '' : '_' . $color;
-            $url = sprintf($this->setIcons['color'], $color);
-        }
+			$color = $color === 'red' ? '' : '_' . $color;
+			$url = sprintf($this->setIcons['alpha'], $color, $char);
+		} else {
+			$color = $color === 'red' ? '' : '_' . $color;
+			$url = sprintf($this->setIcons['color'], $color);
+		}
 
 		/*
         var iconImage = new google.maps.MarkerImage('images/' + images[0] + ' .png',
@@ -1489,7 +1489,7 @@ function geocodeAddress(address) {
 
 		// a position on the map that is supposed to stay visible at all cost
 		if (!empty($mapOptions['visible'])) {
-			$params['visible'] = urlencode((string) $mapOptions['visible']);
+			$params['visible'] = urlencode((string)$mapOptions['visible']);
 		}
 
 		// center and zoom are not necessary if path, visible or markers are given
@@ -1498,7 +1498,7 @@ function geocodeAddress(address) {
 		} elseif ($options['center'] === true && $mapOptions['lat'] !== null && $mapOptions['lng'] !== null) {
 			$params['center'] = urlencode($mapOptions['lat'] . ',' . $mapOptions['lng']);
 		} elseif (!empty($options['center'])) {
-			$params['center'] = urlencode((string) $options['center']);
+			$params['center'] = urlencode((string)$options['center']);
 		} /*else {
 			// try to read from markers array???
 			if (isset($options['markers']) && count($options['markers']) == 1) {
@@ -1507,23 +1507,23 @@ function geocodeAddress(address) {
 		}*/
 
 		if (!isset($options['zoom']) || $options['zoom'] === false) {
-            // dont use it
-        } elseif ($options['zoom'] === 'auto') {
-            if (!empty($options['markers']) && str_contains($options['zoom'], '|')) {
+			// dont use it
+		} elseif ($options['zoom'] === 'auto') {
+			if (!empty($options['markers']) && str_contains($options['zoom'], '|')) {
 					// let google find the best zoom value itself
-				} else {
-					// do something here?
-				}
-        } else {
-				$params['zoom'] = $options['zoom'];
+			} else {
+				// do something here?
 			}
+		} else {
+				$params['zoom'] = $options['zoom'];
+		}
 
 		if (array_key_exists($mapOptions['type'], $this->types)) {
 			$params['maptype'] = $this->types[$mapOptions['type']];
 		} else {
 			$params['maptype'] = $mapOptions['type'];
 		}
-		$params['maptype'] = strtolower((string) $params['maptype']);
+		$params['maptype'] = strtolower((string)$params['maptype']);
 
 		// old: {latitude},{longitude},{color}{alpha-character}
 		// new: @see staticMarkers()
@@ -1599,7 +1599,7 @@ function geocodeAddress(address) {
 
 			$path = [];
 			foreach ($options as $key => $value) {
-				$path[] = $key . ':' . urlencode((string) $value);
+				$path[] = $key . ':' . urlencode((string)$value);
 			}
 			foreach ($markers as $pos) {
 				if (is_array($pos)) {
@@ -1660,7 +1660,7 @@ function geocodeAddress(address) {
 			if (!empty($p['lat']) && !empty($p['lng'])) {
 				$p['address'] = $p['lat'] . ',' . $p['lng'];
 			}
-			$p['address'] = urlencode((string) $p['address']);
+			$p['address'] = urlencode((string)$p['address']);
 
 			$values = [];
 
@@ -1671,7 +1671,7 @@ function geocodeAddress(address) {
 			}
 			// label? A-Z0-9
 			if (!empty($p['label'])) {
-				$values[] = 'label:' . strtoupper((string) $p['label']);
+				$values[] = 'label:' . strtoupper((string)$p['label']);
 			}
 			if (!empty($p['size'])) {
 				$values[] = 'size:' . $p['size'];
@@ -1680,7 +1680,7 @@ function geocodeAddress(address) {
 				$values[] = 'shadow:' . $p['shadow'];
 			}
 			if (!empty($p['icon'])) {
-				$values[] = 'icon:' . urlencode((string) $p['icon']);
+				$values[] = 'icon:' . urlencode((string)$p['icon']);
 			}
 			$values[] = $p['address'];
 
@@ -1755,7 +1755,7 @@ function geocodeAddress(address) {
 	protected function _toObjectParams($array, $asString = true, $keyAsString = false) {
 		$pieces = [];
 		foreach ($array as $key => $value) {
-			$e = ($asString && !str_starts_with((string) $value, 'new ') ? '"' : '');
+			$e = ($asString && !str_starts_with((string)$value, 'new ') ? '"' : '');
 			$ke = ($keyAsString ? '"' : '');
 			$pieces[] = $ke . $key . $ke . ': ' . $e . $value . $e;
 		}

--- a/src/View/Helper/JsBaseEngineTrait.php
+++ b/src/View/Helper/JsBaseEngineTrait.php
@@ -54,7 +54,7 @@ trait JsBaseEngineTrait {
 
 				break;
 			case (is_bool($val)):
-				$val = ($val === true) ? 'true' : 'false';
+				$val = ($val) ? 'true' : 'false';
 
 				break;
 			case (is_int($val)):

--- a/src/View/Helper/LeafletHelper.php
+++ b/src/View/Helper/LeafletHelper.php
@@ -350,9 +350,8 @@ class LeafletHelper extends Helper {
 		unset($divOptions['width'], $divOptions['height']);
 
 		$defaultText = $this->_runtimeConfig['content'] ?? __d('geo', 'Map cannot be displayed!');
-		$result .= $this->Html->tag('div', $defaultText, $divOptions);
 
-		return $result;
+		return $result . $this->Html->tag('div', $defaultText, $divOptions);
 	}
 
 	/**
@@ -656,11 +655,9 @@ class LeafletHelper extends Helper {
 	 * @return string
 	 */
 	public function script(): string {
-		$script = '<script>
+		return '<script>
 		' . $this->finalize(true) . '
 </script>';
-
-		return $script;
 	}
 
 	/**

--- a/src/View/Helper/StaticMapHelper.php
+++ b/src/View/Helper/StaticMapHelper.php
@@ -219,7 +219,7 @@ class StaticMapHelper extends Helper {
 	 * @return \Geo\StaticMap\Provider\StaticMapProviderInterface
 	 */
 	public function provider(?string $name = null): StaticMapProviderInterface {
-		$name = $name ?? $this->_config['provider'];
+		$name ??= $this->_config['provider'];
 
 		if (!isset($this->providerClasses[$name])) {
 			throw new InvalidArgumentException(sprintf('Unknown static map provider: %s', $name));

--- a/tests/TestApp/src/Geocoder/Geocoder.php
+++ b/tests/TestApp/src/Geocoder/Geocoder.php
@@ -52,9 +52,8 @@ class Geocoder extends GeoGeocoder {
 		}
 
 		$addresses = file_get_contents($testFile);
-		$addresses = unserialize($addresses);
 
-		return $addresses;
+		return unserialize($addresses);
 	}
 
 }

--- a/tests/TestApp/src/Model/Behavior/GeocoderBehavior.php
+++ b/tests/TestApp/src/Model/Behavior/GeocoderBehavior.php
@@ -42,9 +42,8 @@ class GeocoderBehavior extends GeoGeocoderBehavior {
 		}
 
 		$addresses = file_get_contents($testFile);
-		$addresses = unserialize($addresses);
 
-		return $addresses;
+		return unserialize($addresses);
 	}
 
 }

--- a/tests/TestApp/src/Model/Table/SpatialAddressesTable.php
+++ b/tests/TestApp/src/Model/Table/SpatialAddressesTable.php
@@ -65,7 +65,7 @@ class SpatialAddressesTable extends Table {
 		// Go through each result and unpack() the binary data
 		$query->formatResults(function($results) use($columns) {
 			return $results->map(function($entity) use($columns) {
-				foreach ($columns as $column => $type) {
+				foreach (array_keys($columns) as $column) {
 					if (!isset($entity->{$column})) {
 						continue;
 					}
@@ -73,13 +73,7 @@ class SpatialAddressesTable extends Table {
 					if (!is_string($entity->{$column})) {
 						continue;
 					}
-					switch ($type) {
-						// TODO support other types, not only POINT
-						case 'point':
-							$entity->{$column} = unpack('x/x/x/x/corder/Ltype/dx/dy', $entity->{$column});
-
-							break;
-					}
+					$entity->{$column} = unpack('x/x/x/x/corder/Ltype/dx/dy', $entity->{$column});
 				}
 
 				return $entity;
@@ -113,13 +107,7 @@ class SpatialAddressesTable extends Table {
 			if (!is_array($data[$column])) {
 				continue;
 			}
-			switch ($type) {
-				// TODO support other types, not only POINT
-				case 'point':
-					$value = sprintf('\'%s(%s)\'', strtoupper($type), implode(' ', $data[$column]));
-
-					break;
-			}
+			$value = sprintf('\'%s(%s)\'', strtoupper($type), implode(' ', $data[$column]));
 			// Set $value on $entity using ST_GeomFromText()
 			$entity->{$column} = $this->query()->func()->ST_GeomFromText([
 				$value => 'literal',

--- a/tests/TestCase/Geocoder/Provider/GeoIpAddressTest.php
+++ b/tests/TestCase/Geocoder/Provider/GeoIpAddressTest.php
@@ -29,7 +29,7 @@ class GeoIpAddressTest extends TestCase {
 		$address = new GeoIpAddress('geo_ip_lookup', new AdminLevelCollection());
 		$address = $address->withHost('example.com');
 
-		$newAddress = $address->withHost(null);
+		$newAddress = $address->withHost();
 
 		$this->assertSame('example.com', $address->getHost());
 		$this->assertNull($newAddress->getHost());

--- a/tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php
@@ -118,7 +118,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testSetDistanceAsVirtualField() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$options = ['lat' => 13.3, 'lng' => 19.2]; //array('order' => array('Address.distance' => 'ASC'));
 		$query = $this->Addresses->find()->find('distance', ...$options);
@@ -135,7 +135,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testSetDistanceAsValueObject() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$coordinates = new Coordinates(13.3, 19.2);
 		$options = ['coordinates' => $coordinates];
@@ -163,7 +163,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testSetDistanceAsVirtualFieldInMiles() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$this->Addresses->removeBehavior('Geocoder'); //FIXME: Shouldnt be necessary ideally
 		$this->Addresses->addBehavior('Geocoder', ['unit' => Calculator::UNIT_MILES]);
@@ -200,7 +200,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testPagination() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$controller = new TestController(new ServerRequest());
 		$controller->getTableLocator()->get('Addresses')->addBehavior('Geocoder');
@@ -308,10 +308,8 @@ class GeocoderBehaviorTest extends TestCase {
 			->with('Missing Place')
 			->willReturn(new AddressCollection([]));
 		$behaviorReflection = new ReflectionMethod($behavior, '_execute');
-		$behaviorReflection->setAccessible(true);
 
 		$property = new ReflectionProperty($behavior, '_Geocoder');
-		$property->setAccessible(true);
 		$property->setValue($behavior, $geocoder);
 
 		$this->assertNull($behaviorReflection->invoke($behavior, 'Missing Place'));

--- a/tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/GeocoderBehaviorTest.php
@@ -118,7 +118,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testSetDistanceAsVirtualField() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!($driver instanceof Mysql) && !($driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$options = ['lat' => 13.3, 'lng' => 19.2]; //array('order' => array('Address.distance' => 'ASC'));
 		$query = $this->Addresses->find()->find('distance', ...$options);
@@ -135,7 +135,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testSetDistanceAsValueObject() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!($driver instanceof Mysql) && !($driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$coordinates = new Coordinates(13.3, 19.2);
 		$options = ['coordinates' => $coordinates];
@@ -163,7 +163,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testSetDistanceAsVirtualFieldInMiles() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!($driver instanceof Mysql) && !($driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$this->Addresses->removeBehavior('Geocoder'); //FIXME: Shouldnt be necessary ideally
 		$this->Addresses->addBehavior('Geocoder', ['unit' => Calculator::UNIT_MILES]);
@@ -200,7 +200,7 @@ class GeocoderBehaviorTest extends TestCase {
 	 */
 	public function testPagination() {
 		$driver = $this->db->getDriver();
-		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'The virtualFields test is only compatible with Mysql/Postgres.');
+		$this->skipIf(!($driver instanceof Mysql) && !($driver instanceof Postgres), 'The virtualFields test is only compatible with Mysql/Postgres.');
 
 		$controller = new TestController(new ServerRequest());
 		$controller->getTableLocator()->get('Addresses')->addBehavior('Geocoder');
@@ -308,8 +308,10 @@ class GeocoderBehaviorTest extends TestCase {
 			->with('Missing Place')
 			->willReturn(new AddressCollection([]));
 		$behaviorReflection = new ReflectionMethod($behavior, '_execute');
+		$behaviorReflection->setAccessible(true);
 
 		$property = new ReflectionProperty($behavior, '_Geocoder');
+		$property->setAccessible(true);
 		$property->setValue($behavior, $geocoder);
 
 		$this->assertNull($behaviorReflection->invoke($behavior, 'Missing Place'));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,7 +13,7 @@ use Geo\GeoPlugin;
 use TestApp\Controller\AppController;
 
 if (!defined('WINDOWS')) {
-	if (DS == '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -18,7 +18,7 @@ foreach ($iterator as $file) {
 	$class = 'Geo\\Test\\Fixture\\' . $name . 'Fixture';
 	try {
 		$object = (new ReflectionClass($class))->getProperty('fields');
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.