### PR TITLE
Allow symfony http-client v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"phpunit/phpunit": "^11.5 || ^12.1 || ^13.0",
 		"psr/http-message": "2.0.x-dev as 1.0.0",
 		"willdurand/geocoder": "^4.6.0 || ^5.0.0",
-		"symfony/http-client": "^6.0 || ^7.0"
+		"symfony/http-client": "^6.0 || ^7.0 || ^8.0"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true,


### PR DESCRIPTION
## Summary
- widen the  dev constraint to allow v8
- verify the geo test areas against the new client major
