### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/GoogleMapHelper.php
+++ b/src/View/Helper/GoogleMapHelper.php
@@ -126,7 +126,7 @@ class GoogleMapHelper extends Helper {
 	/**
 	 * Needed helpers
 	 *
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html', 'Form'];
 

--- a/src/View/Helper/LeafletHelper.php
+++ b/src/View/Helper/LeafletHelper.php
@@ -62,7 +62,7 @@ class LeafletHelper extends Helper {
 	/**
 	 * Needed helpers
 	 *
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/StaticMapHelper.php
+++ b/src/View/Helper/StaticMapHelper.php
@@ -53,7 +53,7 @@ class StaticMapHelper extends Helper {
 	public const PROVIDER_GOOGLE = 'google';
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test